### PR TITLE
Add Proof Create and Verify to benchmarks

### DIFF
--- a/bench/helper.ts
+++ b/bench/helper.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { BbsSignRequest, BbsCreateProofRequest } from "../src";
+import { BbsSignRequest } from "../src";
 import { randomBytes } from "crypto";
 import { Coder } from "@stablelib/base64";
 

--- a/bench/index.ts
+++ b/bench/index.ts
@@ -84,12 +84,12 @@ const run_benchmark = (numberOfMessages: number, messageSizeInBytes: number, num
   };
   
   report(
-    `BBS Create Proof ${numberOfMessages}, ${messageSizeInBytes} byte message(s)`,
+    `BBS Create Proof ${numberOfMessages}, ${messageSizeInBytes} byte message(s), revealing ${numberRevealed} message(s).`,
     benchmark(() => createProof(CreateProofRequest))
   );
   
   report(
-    `BBS Verify Proof ${numberOfMessages}, ${messageSizeInBytes} byte message(s)`,
+    `BBS Verify Proof ${numberOfMessages}, ${messageSizeInBytes} byte message(s), revealing ${numberRevealed} message(s).`,
     benchmark(() => verifyProof(VerifyProofRequest))
   );
 };
@@ -104,17 +104,17 @@ run_benchmark(1, 1000, 1);
 // ---------------------------------------------------------------------------------------------
 
 // ------------------------------ Sign/Verify 10, 100 byte messages ------------------------------
-run_benchmark(10, 100, 3);
+run_benchmark(10, 100, 1);
 // -----------------------------------------------------------------------------------------------
 
 // ------------------------------ Sign/Verify 10, 1000 byte messages ------------------------------
-run_benchmark(10, 1000, 3);
+run_benchmark(10, 1000, 1);
 // -----------------------------------------------------------------------------------------------
 
 // ------------------------------ Sign/Verify 100, 100 byte messages ------------------------------
-run_benchmark(100, 100, 25);
+run_benchmark(100, 100, 1);
 // -----------------------------------------------------------------------------------------------
 
 // ------------------------------ Sign/Verify 100, 1000 byte messages ------------------------------
-run_benchmark(100, 1000, 25);
+run_benchmark(100, 1000, 1);
 // -----------------------------------------------------------------------------------------------

--- a/src/bbsSignature.ts
+++ b/src/bbsSignature.ts
@@ -92,7 +92,7 @@ export const createProof = (request: BbsCreateProofRequest): Uint8Array => {
       })
     );
   } catch (ex) {
-    throw new Error("Failed to create proof: " + ex);
+    throw new Error("Failed to create proof");
   }
 };
 


### PR DESCRIPTION
And a few error reporting fixes in the library.
Note: this fails if more than one attribute is revealed. PR contains improved error label, shown here:

```
Error: internal error in Neon module: Index is out of bounds. Must be between 0 and 1: 2
```