### PR TITLE
ci: update unstable publish to use tags

### DIFF
--- a/scripts/publish_ts.sh
+++ b/scripts/publish_ts.sh
@@ -19,7 +19,7 @@ node scripts/add_stable_install_script.js
 new_version=$(node -pe "require('./package.json').version")
 
 # Version to this new unstable version
-yarn publish --no-git-tag-version --new-version $new_version
+yarn publish --no-git-tag-version --new-version $new_version --tag unstable
 
 # Reset changes to the package.json
 git checkout -- package.json


### PR DESCRIPTION
Updates the unstable publish process to use an `unstable` tag

## Description

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

Package releasing

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
