### PR TITLE
build: add bls benchmarks

### DIFF
--- a/bench/helper.ts
+++ b/bench/helper.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { BbsSignRequest, BbsKeyPair } from "../src";
+import { BbsSignRequest, BbsKeyPair, BlsKeyPair, BlsBbsSignRequest } from "../src";
 import { randomBytes } from "crypto";
 import { Coder } from "@stablelib/base64";
 
@@ -24,11 +24,22 @@ export const generateMessages = (numberOfMessages: number, messageSizeInBytes: n
   return messages;
 };
 
-export const generateSignRequest = (
+export const generateBbsSignRequest = (
   keyPair: BbsKeyPair,
   numberOfMessages: number,
   messageSizeInBytes: number
 ): BbsSignRequest => {
+  return {
+    keyPair,
+    messages: generateMessages(numberOfMessages, messageSizeInBytes),
+  };
+};
+
+export const generateBlsSignRequest = (
+  keyPair: BlsKeyPair,
+  numberOfMessages: number,
+  messageSizeInBytes: number
+): BlsBbsSignRequest => {
   return {
     keyPair,
     messages: generateMessages(numberOfMessages, messageSizeInBytes),


### PR DESCRIPTION
Adds runnable benchmarks for blsSign which is a bbs sign plus a bls to bbs key conversion

## Description

Adds runnable benchmarks for blsSign which is a bbs sign plus a bls to bbs key conversion

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

Benchmark reporting so consumers know the performance

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
