### PR TITLE
ci(gh-actions): add support for node11/node12 binaries to be published

### DIFF
--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -1,4 +1,3 @@
-
 name: any-pr
 
 on: [pull_request]
@@ -9,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [10.x, 11.x, 12.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [10.x, 11.x, 12.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -11,42 +11,42 @@ jobs:
     if: "contains(github.event.head_commit.message, 'chore(release): publish')"
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-          node-version: [10.x]
+      matrix:
+        node-version: [10.x, 11.x, 12.x]
     steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-node@v1
-          with:
-            node-version: ${{ matrix.node-version }}
-        - run: yarn
-        - run: yarn install --frozen-lockfile
-        - run: yarn lint
-        - run: yarn build
-        - run: yarn test
-        - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc 2> /dev/null
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            NPM_TOKEN: ${{ secrets.NPMJS_TOKEN }}
-        - run: git config user.name "Mattr CI"
-        - run: git config user.email "npmjs_ci_mattr_public@mattr.global"
-        - run: yarn publish:ts
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn build
+      - run: yarn test
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc 2> /dev/null
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+      - run: git config user.name "Mattr CI"
+      - run: git config user.email "npmjs_ci_mattr_public@mattr.global"
+      - run: yarn publish:ts
   build_pub_binaries:
     name: Publish binaries for supported environments for release
     if: "contains(github.event.head_commit.message, 'chore(release): publish')"
     needs: build_test_publish
     runs-on: ${{matrix.os}}
     strategy:
-        matrix:
-          node-version: [10.x]
-          os: [windows-latest, macos-latest, ubuntu-latest]
+      matrix:
+        node-version: [10.x, 11.x, 12.x]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-node@v1
-          with:
-            node-version: ${{ matrix.node-version }}
-        - run: yarn
-        - run: yarn install --frozen-lockfile
-        - run: yarn build
-        - run: yarn publish:binary
-          env:
-            NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn publish:binary
+        env:
+          NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#100

<!---
Provide a general summary of your changes in the Title above
-->

## Description

<!--- Describe your changes in detail -->

- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Allows users of newer versions of node to be able to have published binaries as well. In particular, consumers who use node12 should now be able to use this library.

See  issue #100 for details
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
