### PR TITLE
ci: update release workflow

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -6,13 +6,34 @@ on:
       - master
 
 jobs:
-  build_test_publish:
-    name: Build, test, and publish release
+  build_pub_binaries:
+    name: Publish binaries for supported environments for release
     if: "contains(github.event.head_commit.message, 'chore(release): publish')"
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
     strategy:
       matrix:
         node-version: [10.x, 11.x, 12.x]
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn test
+      - run: yarn publish:binary
+        env:
+          NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build_test_publish:
+    name: Build, test, and publish release
+    if: "contains(github.event.head_commit.message, 'chore(release): publish')"
+    needs: build_pub_binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -30,23 +51,3 @@ jobs:
       - run: git config user.name "Mattr CI"
       - run: git config user.email "npmjs_ci_mattr_public@mattr.global"
       - run: yarn publish:ts
-  build_pub_binaries:
-    name: Publish binaries for supported environments for release
-    if: "contains(github.event.head_commit.message, 'chore(release): publish')"
-    needs: build_test_publish
-    runs-on: ${{matrix.os}}
-    strategy:
-      matrix:
-        node-version: [10.x, 11.x, 12.x]
-        os: [windows-latest, macos-latest, ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: yarn
-      - run: yarn install --frozen-lockfile
-      - run: yarn build
-      - run: yarn publish:binary
-        env:
-          NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Attempting to publish the same package for different node versions fails, we are testing the integration of the package with push-release workflow hence do not need to test on all unstable releases and pull requests.

This PR also updates the push-release workflow to test the package across the different node versions prior to publishing the actual package to NPM.

## Description

Attempting to publish the same package for different node versions fails, we are testing the integration of the package with push-release workflow hence do not need to test on all unstable releases and pull requests.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

Robust build pipeline

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
