### PR TITLE
refactor: change messages and nonce from string to uint8array

### DIFF
--- a/__tests__/bbsSignature/createProof.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/createProof.bbsSignature.spec.ts
@@ -12,23 +12,13 @@
  */
 
 import { BbsCreateProofRequest, createProof, blsCreateProof } from "../../src";
-import { Coder } from "@stablelib/base64";
 import { randomBytes } from "@stablelib/random";
-
-const base64Encode = (bytes: Uint8Array): string => {
-  const coder = new Coder();
-  return coder.encode(bytes);
-};
-
-const base64Decode = (string: string): Uint8Array => {
-  const coder = new Coder();
-  return coder.decode(string);
-};
+import { base64Decode, stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
   describe("createProof", () => {
     it("should create proof revealing single message from single message signature", () => {
-      const messages = ["RmtnDBJHso5iSg=="];
+      const messages = [stringToBytes("RmtnDBJHso5iSg==")];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pboZyjM38YgjaUBcjftZi5gb58Qz13XeRJpiuUHH06I7/1Eb8oVtIW5SGMNfKaqKhBAAAAAYPPztgxfWWw01/0SSug1oLfVuI4XUqhgyZ3rS6eTkOLjnyR3ObXb0XCD2Mfcxiv6w=="
       );
@@ -40,7 +30,7 @@ describe("bbsSignature", () => {
         signature,
         publicKey: bbsPublicKey,
         messages,
-        nonce: "0123456789",
+        nonce: stringToBytes("0123456789"),
         revealed: [0],
       };
 
@@ -50,7 +40,11 @@ describe("bbsSignature", () => {
     });
 
     it("should create proof revealing all messages from multi-message signature", () => {
-      const messages = ["J42AxhciOVkE9w==", "PNMnARWIHP+s2g==", "ti9WYhhEej85jw=="];
+      const messages = [
+        stringToBytes("J42AxhciOVkE9w=="),
+        stringToBytes("PNMnARWIHP+s2g=="),
+        stringToBytes("ti9WYhhEej85jw=="),
+      ];
 
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA=="
@@ -63,7 +57,7 @@ describe("bbsSignature", () => {
         signature,
         publicKey: bbsPublicKey,
         messages,
-        nonce: base64Encode(randomBytes(10)),
+        nonce: randomBytes(10),
         revealed: [0, 1, 2],
       };
 
@@ -73,7 +67,11 @@ describe("bbsSignature", () => {
     });
 
     it("should create proof revealing single message from multi-message signature", () => {
-      const messages = ["J42AxhciOVkE9w==", "PNMnARWIHP+s2g==", "ti9WYhhEej85jw=="];
+      const messages = [
+        stringToBytes("J42AxhciOVkE9w=="),
+        stringToBytes("PNMnARWIHP+s2g=="),
+        stringToBytes("ti9WYhhEej85jw=="),
+      ];
 
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA=="
@@ -86,7 +84,7 @@ describe("bbsSignature", () => {
         signature,
         publicKey: bbsPublicKey,
         messages,
-        nonce: base64Encode(randomBytes(10)),
+        nonce: randomBytes(10),
         revealed: [0],
       };
 
@@ -96,7 +94,11 @@ describe("bbsSignature", () => {
     });
 
     it("should create proof revealing multiple messages from multi-message signature", () => {
-      const messages = ["J42AxhciOVkE9w==", "PNMnARWIHP+s2g==", "ti9WYhhEej85jw=="];
+      const messages = [
+        stringToBytes("J42AxhciOVkE9w=="),
+        stringToBytes("PNMnARWIHP+s2g=="),
+        stringToBytes("ti9WYhhEej85jw=="),
+      ];
 
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA=="
@@ -109,7 +111,7 @@ describe("bbsSignature", () => {
         signature,
         publicKey: bbsPublicKey,
         messages,
-        nonce: base64Encode(randomBytes(10)),
+        nonce: randomBytes(10),
         revealed: [0, 2],
       };
 
@@ -121,7 +123,7 @@ describe("bbsSignature", () => {
 
   describe("blsCreateProof", () => {
     it("should create proof revealing single message from single message signature", () => {
-      const messages = ["uzAoQFqLgReidw=="];
+      const messages = [stringToBytes("uzAoQFqLgReidw==")];
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
       );
@@ -133,7 +135,7 @@ describe("bbsSignature", () => {
         signature,
         publicKey: blsPublicKey,
         messages,
-        nonce: "0123456789",
+        nonce: stringToBytes("0123456789"),
         revealed: [0],
       };
 
@@ -143,7 +145,11 @@ describe("bbsSignature", () => {
     });
 
     it("should create proof revealing all messages from multi-message signature", () => {
-      const messages = ["C+n1rPz1/tVzPg==", "h3x8cbySqC4rLA==", "MGf74ofGdRwNbw=="];
+      const messages = [
+        stringToBytes("C+n1rPz1/tVzPg=="),
+        stringToBytes("h3x8cbySqC4rLA=="),
+        stringToBytes("MGf74ofGdRwNbw=="),
+      ];
 
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
@@ -156,7 +162,7 @@ describe("bbsSignature", () => {
         signature,
         publicKey: blsPublicKey,
         messages,
-        nonce: base64Encode(randomBytes(10)),
+        nonce: randomBytes(10),
         revealed: [0, 1, 2],
       };
 
@@ -166,7 +172,11 @@ describe("bbsSignature", () => {
     });
 
     it("should create proof revealing single message from multi-message signature", () => {
-      const messages = ["uiSKIfNoO2rMrA==", "lMoHHrFx0LxwAw==", "wdwqLVm9chMMnA=="];
+      const messages = [
+        stringToBytes("uiSKIfNoO2rMrA=="),
+        stringToBytes("lMoHHrFx0LxwAw=="),
+        stringToBytes("wdwqLVm9chMMnA=="),
+      ];
 
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
@@ -179,7 +189,7 @@ describe("bbsSignature", () => {
         signature,
         publicKey: blsPublicKey,
         messages,
-        nonce: base64Encode(randomBytes(10)),
+        nonce: randomBytes(10),
         revealed: [0],
       };
 
@@ -189,7 +199,11 @@ describe("bbsSignature", () => {
     });
 
     it("should create proof revealing multiple messages from multi-message signature", () => {
-      const messages = ["uiSKIfNoO2rMrA==", "lMoHHrFx0LxwAw==", "wdwqLVm9chMMnA=="];
+      const messages = [
+        stringToBytes("uiSKIfNoO2rMrA=="),
+        stringToBytes("lMoHHrFx0LxwAw=="),
+        stringToBytes("wdwqLVm9chMMnA=="),
+      ];
 
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
@@ -202,7 +216,7 @@ describe("bbsSignature", () => {
         signature,
         publicKey: blsPublicKey,
         messages,
-        nonce: base64Encode(randomBytes(10)),
+        nonce: randomBytes(10),
         revealed: [0, 2],
       };
 

--- a/__tests__/bbsSignature/sign.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/sign.bbsSignature.spec.ts
@@ -22,6 +22,7 @@ import {
   blsSign,
   BlsKeyPair,
 } from "../../src";
+import { stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
   const blsKeyPair = generateBls12381KeyPair();
@@ -32,7 +33,7 @@ describe("bbsSignature", () => {
       const bbsKeyPair = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
       const request: BbsSignRequest = {
         keyPair: bbsKeyPair,
-        messages: ["ExampleMessage"],
+        messages: [stringToBytes("ExampleMessage")],
       };
       const signature = sign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
@@ -42,7 +43,7 @@ describe("bbsSignature", () => {
     it("should sign multiple messages", () => {
       const request: BbsSignRequest = {
         keyPair: bbsKeyPair,
-        messages: ["ExampleMessage", "ExampleMessage2", "ExampleMessage3"],
+        messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
       };
       const signature = sign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
@@ -52,7 +53,7 @@ describe("bbsSignature", () => {
     it("should sign multiple messages when public key supports more", () => {
       const request: BbsSignRequest = {
         keyPair: bbsKeyPair,
-        messages: ["ExampleMessage", "ExampleMessage"],
+        messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage")],
       };
       const signature = sign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
@@ -66,7 +67,7 @@ describe("bbsSignature", () => {
       };
       const request: BbsSignRequest = {
         keyPair: bbsKey,
-        messages: ["ExampleMessage"],
+        messages: [stringToBytes("ExampleMessage")],
       };
       expect(() => sign(request)).toThrowError("Failed to sign");
     });
@@ -75,7 +76,7 @@ describe("bbsSignature", () => {
       const bbsKeyPair = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
       const request: BbsSignRequest = {
         keyPair: bbsKeyPair,
-        messages: ["ExampleMessage", "ExampleMessage", "ExampleMessage"],
+        messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage")],
       };
       expect(() => sign(request)).toThrowError("Failed to sign");
     });
@@ -85,7 +86,7 @@ describe("bbsSignature", () => {
     it("should sign a single message", () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
-        messages: ["ExampleMessage"],
+        messages: [stringToBytes("ExampleMessage")],
       };
       const signature = blsSign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
@@ -95,7 +96,7 @@ describe("bbsSignature", () => {
     it("should sign multiple messages", () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
-        messages: ["ExampleMessage", "ExampleMessage2", "ExampleMessage3"],
+        messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
       };
       const signature = blsSign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
@@ -108,7 +109,7 @@ describe("bbsSignature", () => {
       };
       const request: BlsBbsSignRequest = {
         keyPair: blsKey,
-        messages: ["ExampleMessage", "ExampleMessage2", "ExampleMessage3"],
+        messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
       };
       expect(() => blsSign(request)).toThrowError("Failed to sign");
     });

--- a/__tests__/bbsSignature/verify.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/verify.bbsSignature.spec.ts
@@ -23,12 +23,7 @@ import {
   blsSign,
   BlsBbsVerifyRequest,
 } from "../../src";
-import { Coder } from "@stablelib/base64";
-
-const base64Decode = (string: string): Uint8Array => {
-  const coder = new Coder();
-  return coder.decode(string);
-};
+import { base64Decode, stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
   describe("verify", () => {
@@ -37,12 +32,12 @@ describe("bbsSignature", () => {
       const BbsPublicKey = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
       const request: BbsSignRequest = {
         keyPair: BbsPublicKey,
-        messages: ["ExampleMessage"],
+        messages: [stringToBytes("ExampleMessage")],
       };
       const signature = sign(request);
       const verifyRequest: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
-        messages: ["ExampleMessage"],
+        messages: [stringToBytes("ExampleMessage")],
         signature,
       };
       const result = verify(verifyRequest);
@@ -53,19 +48,19 @@ describe("bbsSignature", () => {
       const BbsPublicKey = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 3 });
       const request: BbsSignRequest = {
         keyPair: BbsPublicKey,
-        messages: ["ExampleMessage", "ExampleMessage2", "ExampleMessage3"],
+        messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
       };
       const signature = sign(request);
       const verifyRequest: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
-        messages: ["ExampleMessage", "ExampleMessage2", "ExampleMessage3"],
+        messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
         signature: signature,
       };
       expect(verify(verifyRequest).verified).toBeTruthy();
     });
 
     it("should not verify valid signature with wrong single message", () => {
-      const messages = ["BadMessage"];
+      const messages = [stringToBytes("BadMessage")];
       const BbsPublicKey = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
       const verifyRequest: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
@@ -78,7 +73,7 @@ describe("bbsSignature", () => {
     });
 
     it("should not verify valid signature with wrong messages", () => {
-      const messages = ["BadMessage", "BadMessage", "BadMessage"];
+      const messages = [stringToBytes("BadMessage"), stringToBytes("BadMessage"), stringToBytes("BadMessage")];
       const BbsPublicKey = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 3 });
       const verifyRequest: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
@@ -118,12 +113,12 @@ describe("bbsSignature", () => {
     it("should verify valid signature with a single message", () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
-        messages: ["ExampleMessage"],
+        messages: [stringToBytes("ExampleMessage")],
       };
       const signature = blsSign(request);
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
-        messages: ["ExampleMessage"],
+        messages: [stringToBytes("ExampleMessage")],
         signature,
       };
       expect(blsVerify(verifyRequest).verified).toBeTruthy();
@@ -132,19 +127,19 @@ describe("bbsSignature", () => {
     it("should verify valid signature with multiple messages", () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
-        messages: ["ExampleMessage", "ExampleMessage2", "ExampleMessage3"],
+        messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
       };
       const signature = blsSign(request);
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
-        messages: ["ExampleMessage", "ExampleMessage2", "ExampleMessage3"],
+        messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
         signature,
       };
       expect(blsVerify(verifyRequest).verified).toBeTruthy();
     });
 
     it("should not verify valid signature with wrong single message", () => {
-      const messages = ["BadMessage"];
+      const messages = [stringToBytes("BadMessage")];
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
         messages,
@@ -156,7 +151,7 @@ describe("bbsSignature", () => {
     });
 
     it("should not verify valid signature with wrong messages", () => {
-      const messages = ["BadMessage", "BadMessage", "BadMessage"];
+      const messages = [stringToBytes("BadMessage"), stringToBytes("BadMessage"), stringToBytes("BadMessage")];
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
         messages,

--- a/__tests__/bbsSignature/verifyProof.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/verifyProof.bbsSignature.spec.ts
@@ -12,18 +12,13 @@
  */
 
 import { BbsVerifyProofRequest, verifyProof, blsVerifyProof, BbsCreateProofRequest } from "../../src";
-import { Coder } from "@stablelib/base64";
 import { createProof } from "../../lib";
-
-const base64Decode = (string: string): Uint8Array => {
-  const coder = new Coder();
-  return coder.decode(string);
-};
+import { base64Decode, stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
   describe("verifyProof", () => {
     it("should verify proof with all messages revealed from single message signature", () => {
-      const messages = ["KNK0ITRAF+NrGg=="];
+      const messages = [stringToBytes("KNK0ITRAF+NrGg==")];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pboZyjM38YgjaUBcjftZi5gb58Qz13XeRJpiuUHH06I7/1Eb8oVtIW5SGMNfKaqKhBAAAAAYPPztgxfWWw01/0SSug1oLfVuI4XUqhgyZ3rS6eTkOLjnyR3ObXb0XCD2Mfcxiv6w=="
       );
@@ -35,14 +30,18 @@ describe("bbsSignature", () => {
         proof,
         publicKey: bbsPublicKey,
         messages,
-        nonce: "v3bb/Mz+JajUdiM2URfZYcPuqxw=",
+        nonce: stringToBytes("v3bb/Mz+JajUdiM2URfZYcPuqxw="),
       };
 
       expect(verifyProof(request).verified).toBeTruthy();
     });
 
     it("should verify proof with all messages revealed from multi message signature", () => {
-      const messages = ["BVB6lAn912sz9Q==", "b45VqRkIo5R5Zw==", "yPqox0TIKS6vCA=="];
+      const messages = [
+        stringToBytes("BVB6lAn912sz9Q=="),
+        stringToBytes("b45VqRkIo5R5Zw=="),
+        stringToBytes("yPqox0TIKS6vCA=="),
+      ];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA=="
       );
@@ -54,14 +53,18 @@ describe("bbsSignature", () => {
         proof,
         publicKey: bbsPublicKey,
         messages,
-        nonce: "dVPpzuQtJVAZzAw73beWiXLtoT4=",
+        nonce: stringToBytes("dVPpzuQtJVAZzAw73beWiXLtoT4="),
       };
 
       expect(verifyProof(request).verified).toBeTruthy();
     });
 
     it("should verify proof with one message revealed from multi-message signature", () => {
-      const messages = ["+FxEv3VLcNZ8sA==", "eI2RcRExnbP8hw==", "wll4zckqWAb0Kg=="];
+      const messages = [
+        stringToBytes("+FxEv3VLcNZ8sA=="),
+        stringToBytes("eI2RcRExnbP8hw=="),
+        stringToBytes("wll4zckqWAb0Kg=="),
+      ];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA=="
       );
@@ -75,14 +78,14 @@ describe("bbsSignature", () => {
         proof,
         publicKey: bbsPublicKey,
         messages: revealedMessages,
-        nonce: "NoWZhtX+u1wWLtUfPMmku1FtU2I=",
+        nonce: stringToBytes("NoWZhtX+u1wWLtUfPMmku1FtU2I="),
       };
 
       expect(verifyProof(request).verified).toBeTruthy();
     });
 
     it("should not verify with bad nonce", () => {
-      const messages = ["KNK0ITRAF+NrGg=="];
+      const messages = [stringToBytes("KNK0ITRAF+NrGg==")];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pboZyjM38YgjaUBcjftZi5gb58Qz13XeRJpiuUHH06I7/1Eb8oVtIW5SGMNfKaqKhBAAAAAYPPztgxfWWw01/0SSug1oLfVuI4XUqhgyZ3rS6eTkOLjnyR3ObXb0XCD2Mfcxiv6w=="
       );
@@ -94,7 +97,7 @@ describe("bbsSignature", () => {
         proof,
         publicKey: bbsPublicKey,
         messages,
-        nonce: "bad",
+        nonce: stringToBytes("bad"),
       };
 
       expect(verifyProof(request).verified).toBeFalsy();
@@ -102,7 +105,12 @@ describe("bbsSignature", () => {
 
     it("should not verify with a message that wasn't signed", () => {
       // Expects messages to be ["Message1", "Message2", "Message3", "Message4"];
-      const messages = ["BadMessage1", "Message2", "Message3", "Message4"];
+      const messages = [
+        stringToBytes("BadMessage1"),
+        stringToBytes("Message2"),
+        stringToBytes("Message3"),
+        stringToBytes("Message4"),
+      ];
       const bbsPublicKey = base64Decode(
         "S+bRoSJJOet/8hKDpXFV+8TXzg0gPcD64lMFtIUzhYtMJAnNqfJRJnFIS0Vs2VC8AK6MBa6TYgILMqVv4RTSEl3H66mOF6jrEOHelKGlkJCNY8u3bI2aXrmqTkhnjxck"
       );
@@ -114,21 +122,26 @@ describe("bbsSignature", () => {
         proof,
         publicKey: bbsPublicKey,
         messages,
-        nonce: "0123456789",
+        nonce: stringToBytes("0123456789"),
       };
       expect(verifyProof(request).verified).toBeFalsy();
     });
   });
 
   it("should not verify with revealed message that was supposed to be hidden", () => {
-    const messages = ["Message1", "Message2", "Message3", "Message4"];
+    const messages = [
+      stringToBytes("Message1"),
+      stringToBytes("Message2"),
+      stringToBytes("Message3"),
+      stringToBytes("Message4"),
+    ];
     const signature = base64Decode(
       "j46NB7z6EBzD6q8bwBfzNYmjab3LPVoU7swcxO4qukq+qx0TrJhmo1TAW5UpDIFWSdb5kgWLAda2giwW4GImPTl8yWwIBJksnfT7zD8nonsvVaJh15/YrQ/n5KlknD4OtLTquji9RJK1U/xWzERHtA=="
     );
     const bbsPublicKey = base64Decode(
       "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbosOXSMyokWdxxfboF4VchlaYCp6XTOpMx4eyDYmBELxlb71I+QX1EGjnMnqAWZALAAAABKw+umnxXMNjIO3KXpByQV8QUtZdLanMRAho0zu8eUHbpCa8+v+Hlz+ziXN62rCmToaOrGXpFkFlUDFdw3gMUlYoWo40rF5sy4v8gci5xS1SHYnz3SAeUJ/wzT3RKEv3PbIxyz5fihZJFqz1XdL7KK2I8eNtnTU7L3xFrsFQ4YTkl2bQSS/cix8zYW3ane6WGIbfFUf4yFDsXmDT0THKKoly245B3nW/s5VfMDDaqWfsK4HThMgm9bOyeOuNultvNg=="
     );
-    const nonce = "0123456789";
+    const nonce = stringToBytes("0123456789");
 
     const proofRequest: BbsCreateProofRequest = {
       signature,
@@ -139,7 +152,7 @@ describe("bbsSignature", () => {
     };
     const proof = createProof(proofRequest);
 
-    let proofMessages = ["BadMessage9"];
+    let proofMessages = [stringToBytes("BadMessage9")];
     let request = {
       proof,
       publicKey: bbsPublicKey,
@@ -151,7 +164,7 @@ describe("bbsSignature", () => {
 
     expect(verifyProof(request).verified).toBeFalsy();
 
-    proofMessages = ["Message1"];
+    proofMessages = [stringToBytes("Message1")];
     request = {
       proof,
       publicKey: bbsPublicKey,
@@ -165,7 +178,7 @@ describe("bbsSignature", () => {
 
   describe("blsVerifyProof", () => {
     it("should verify proof with all messages revealed from single message signature", () => {
-      const messages = ["KnYAbm0fw3mlUA=="];
+      const messages = [stringToBytes("KnYAbm0fw3mlUA==")];
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
       );
@@ -177,14 +190,18 @@ describe("bbsSignature", () => {
         proof,
         publicKey: blsPublicKey,
         messages,
-        nonce: "4OS3nji2HNReo3QPHrdlxjOf8gc=",
+        nonce: stringToBytes("4OS3nji2HNReo3QPHrdlxjOf8gc="),
       };
 
       expect(blsVerifyProof(request).verified).toBeTruthy();
     });
 
     it("should verify proof with all messages revealed from multi message signature", () => {
-      const messages = ["ODLpUKee6nyz7g==", "v2zteJajIyIh5Q==", "x64hA8TTn4gYXg=="];
+      const messages = [
+        stringToBytes("ODLpUKee6nyz7g=="),
+        stringToBytes("v2zteJajIyIh5Q=="),
+        stringToBytes("x64hA8TTn4gYXg=="),
+      ];
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
       );
@@ -196,14 +213,18 @@ describe("bbsSignature", () => {
         proof,
         publicKey: blsPublicKey,
         messages,
-        nonce: "ujMevaaq2n7Cg3ZLzXktqT/WRgM=",
+        nonce: stringToBytes("ujMevaaq2n7Cg3ZLzXktqT/WRgM="),
       };
 
       expect(blsVerifyProof(request).verified).toBeTruthy();
     });
 
     it("should verify proof with one message revealed from multi-message signature", () => {
-      const messages = ["8NhsJO/MKxO74A==", "0noLBcl29ASJ2w==", "eMPpY348vqGDNA=="];
+      const messages = [
+        stringToBytes("8NhsJO/MKxO74A=="),
+        stringToBytes("0noLBcl29ASJ2w=="),
+        stringToBytes("eMPpY348vqGDNA=="),
+      ];
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
       );
@@ -217,14 +238,14 @@ describe("bbsSignature", () => {
         proof,
         publicKey: blsPublicKey,
         messages: revealedMessages,
-        nonce: "I03DvFXcpVdOPuOiyXgcBf4voAA=",
+        nonce: stringToBytes("I03DvFXcpVdOPuOiyXgcBf4voAA="),
       };
 
       expect(blsVerifyProof(request).verified).toBeTruthy();
     });
 
     it("should not verify with bad nonce", () => {
-      const messages = ["KnYAbm0fw3mlUA=="];
+      const messages = [stringToBytes("KnYAbm0fw3mlUA==")];
       const blsPublicKey = base64Decode(
         "x45gpyN9ryZHcdlbJCKrM6WAPI6BggO97nmTcimnXwFA7AeMf54x7atqH0BvxV4UA3f7DcWHpq0HEytVwin7pd/AZXjexfTynNgUgVdd/xkcRdwKCgBMnEx5R7csAGVm"
       );
@@ -236,7 +257,7 @@ describe("bbsSignature", () => {
         proof,
         publicKey: blsPublicKey,
         messages,
-        nonce: "bad",
+        nonce: stringToBytes("bad"),
       };
 
       expect(blsVerifyProof(request).verified).toBeFalsy();

--- a/__tests__/utilities/index.ts
+++ b/__tests__/utilities/index.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 - MATTR Limited
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Coder } from "@stablelib/base64";
+
+/**
+ * Encodes a Uint8Array to a base64 string
+ * @param bytes Input Uin8Array
+ */
+export const base64Encode = (bytes: Uint8Array): string => {
+  const coder = new Coder();
+  return coder.encode(bytes);
+};
+/**
+ * Decodes a base64 string to a Uint8Array
+ * @param bytes Input base64 string
+ */
+
+export const base64Decode = (string: string): Uint8Array => {
+  const coder = new Coder();
+  return coder.decode(string);
+};
+
+/**
+ * Converts a UTF-8 Encoded string to a byte array
+ * @param string
+ */
+export const stringToBytes = (string: string): Uint8Array => Uint8Array.from(Buffer.from(string, "utf-8"));

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -2,18 +2,24 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.10"
+name = "adler"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+checksum = "ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10"
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
@@ -32,28 +38,29 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.48"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
+checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
 
 [[package]]
 name = "base64"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bbs"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbe7ae2cbe070c0feabb21717d506de61fffc8fbd6bb770fa21208ddd7278f2"
+checksum = "7e24ff98879bedb7fe7b3ce0c86268baca8468e8ce405d44459dbaf0b26ac9ca"
 dependencies = [
  "arrayref",
  "blake2",
@@ -94,9 +101,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cc"
-version = "1.0.53"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c"
+checksum = "0fde55d2a2bfaa4c9668bbc63f531fbdeee3ffe188f4662511ce2c22b3eedebe"
 
 [[package]]
 name = "cfg-if"
@@ -132,12 +139,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -258,15 +266,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -305,9 +313,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "maybe-uninit"
@@ -323,11 +331,20 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -396,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -406,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]
@@ -425,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "opaque-debug"
@@ -458,18 +475,18 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
@@ -554,10 +571,11 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+checksum = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
 dependencies = [
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -565,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
+checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
@@ -587,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.7"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -599,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "rustc-demangle"
@@ -632,18 +650,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.110"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.110"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -658,9 +676,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.22"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -669,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -696,9 +714,9 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "wasi"
@@ -708,9 +726,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,12 +10,12 @@ name = "node_bbs_signatures"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-neon-build = "0.4.0"
+neon-build = "0.4"
 
 [dependencies]
-arrayref = "0.3.6"
-bbs = "0.4.0"
-neon = "0.4.0"
+arrayref = "0.3"
+bbs = "0.4"
+neon = "0.4"
 
 [dev-dependencies]
 base64 = "0.12"

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -655,7 +655,7 @@ fn bls_verify_proof(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 ///     "proof": ArrayBuffer,                   // The proof from `bbs_create_proof`
 ///     "publicKey": ArrayBuffer,               // The public key of the signer
 ///     "messages": [ArrayBuffer, ArrayBuffer]  // The revealed messages as strings. They will be Blake2b hashed.
-///     "nonce": String                         // This is an optional nonce from the verifier and will be used in the proof of committed messages if present. It is strongly recommend that this be used.
+///     "nonce": ArrayBuffer                    // This is an optional nonce from the verifier and will be used in the proof of committed messages if present. It is strongly recommend that this be used.
 /// }
 ///
 /// `return`: true if valid
@@ -733,19 +733,6 @@ fn extract_verify_proof_context(cx: &mut FunctionContext, is_bls: bool) -> Resul
     if public_key.validate().is_err() {
         panic!("Invalid key");
     }
-
-    // let message_count = public_key.message_count() as f64;
-    // let mut revealed = BTreeSet::new();
-    // for i in 0..revealed_indices.len() {
-    //     let index = cast_to_number!(cx, revealed_indices[i]);
-    //     if index < 0f64 || index > message_count {
-    //         panic!(
-    //             "Index is out of bounds. Must be between 0 and {}: {}",
-    //             message_count, index
-    //         );
-    //     }
-    //     revealed.insert(index as usize);
-    // }
 
     Ok(VerifyProofContext {
         proof,

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -125,7 +125,7 @@ fn bls_public_key_to_bbs_key(mut cx: FunctionContext) -> JsResult<JsArrayBuffer>
 /// {
 ///     "secretKey": ArrayBuffer                // The private key of signer
 ///     "publicKey": ArrayBuffer                // The public key of signer
-///     "messages": [ArrayBuffer, ArrayBuffer], // The messages to be signed as strings. They will be hashed with Blake2b
+///     "messages": [ArrayBuffer, ArrayBuffer], // The messages to be signed as ArrayBuffers. They will be hashed with Blake2b
 /// }
 ///
 /// `return`: `ArrayBuffer` the signature
@@ -170,7 +170,7 @@ fn bbs_sign(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
 /// {
 ///     "publicKey": ArrayBuffer                // The public key
 ///     "signature": ArrayBuffer                // The signature
-///     "messages": [ArrayBuffer, ArrayBuffer], // The messages that were signed as strings. They will be Blake2b hashed
+///     "messages": [ArrayBuffer, ArrayBuffer], // The messages that were signed as ArrayBuffers. They will be Blake2b hashed
 /// }
 ///
 /// `return`: true if valid `signature` on `messages`
@@ -219,7 +219,7 @@ fn bbs_verify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 /// The context object model is as follows:
 /// {
 ///     "publicKey": ArrayBuffer                // The public key of signer
-///     "messages": [ArrayBuffer, ArrayBuffer], // The messages that will be blinded as strings. They will be Blake2b hashed
+///     "messages": [ArrayBuffer, ArrayBuffer], // The messages that will be blinded as ArrayBuffers. They will be Blake2b hashed
 ///     "blinded": [Number, Number],            // The zero based indices to the generators in the public key for the messages.
 ///     "nonce": ArrayBuffer                    // This is an optional nonce from the signer and will be used in the proof of committed messages if present. It is strongly recommend that this be used.
 /// }
@@ -632,7 +632,7 @@ struct CreateProofContext {
 /// {
 ///     "proof": ArrayBuffer,                   // The proof from `bbs_create_proof`
 ///     "publicKey": ArrayBuffer,               // The public key of the signer in BLS form
-///     "messages": [ArrayBuffer, ArrayBuffer]  // The revealed messages as strings. They will be Blake2b hashed.
+///     "messages": [ArrayBuffer, ArrayBuffer]  // The revealed messages as ArrayBuffers. They will be Blake2b hashed.
 ///     "nonce": ArrayBuffer                    // This is an optional nonce from the verifier and will be used in the proof of committed messages if present. It is strongly recommend that this be used.
 /// }
 ///
@@ -654,7 +654,7 @@ fn bls_verify_proof(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 /// {
 ///     "proof": ArrayBuffer,                   // The proof from `bbs_create_proof`
 ///     "publicKey": ArrayBuffer,               // The public key of the signer
-///     "messages": [ArrayBuffer, ArrayBuffer]  // The revealed messages as strings. They will be Blake2b hashed.
+///     "messages": [ArrayBuffer, ArrayBuffer]  // The revealed messages as ArrayBuffers. They will be Blake2b hashed.
 ///     "nonce": ArrayBuffer                    // This is an optional nonce from the verifier and will be used in the proof of committed messages if present. It is strongly recommend that this be used.
 /// }
 ///

--- a/native/src/macros.rs
+++ b/native/src/macros.rs
@@ -55,15 +55,6 @@ macro_rules! obj_field_to_fixed_array {
     }};
 }
 
-// macro_rules! obj_field_to_opt_string {
-//     ($cx:expr, $obj:expr, $field:expr) => {{
-//         match $obj.get($cx, $field)?.downcast::<JsString>().or_throw($cx) {
-//             Err(_) => None,
-//             Ok(arg) => Some(arg.value()),
-//         }
-//     }};
-// }
-
 macro_rules! obj_field_to_opt_slice {
     ($cx:expr, $obj:expr, $field:expr) => {{
         match $obj.get($cx, $field)?.downcast::<JsArrayBuffer>().or_throw($cx) {
@@ -90,14 +81,6 @@ macro_rules! cast_to_slice {
         $cx.borrow(&arg, |d| d.as_slice::<u8>()).to_vec()
     }};
 }
-
-// macro_rules! cast_to_string {
-//     ($cx:expr, $obj:expr) => {{
-//         $obj.downcast::<JsString>()
-//             .unwrap_or($cx.string(""))
-//             .value()
-//     }};
-// }
 
 macro_rules! cast_to_number {
     ($cx:expr, $obj:expr) => {

--- a/native/src/macros.rs
+++ b/native/src/macros.rs
@@ -55,11 +55,20 @@ macro_rules! obj_field_to_fixed_array {
     }};
 }
 
-macro_rules! obj_field_to_opt_string {
+// macro_rules! obj_field_to_opt_string {
+//     ($cx:expr, $obj:expr, $field:expr) => {{
+//         match $obj.get($cx, $field)?.downcast::<JsString>().or_throw($cx) {
+//             Err(_) => None,
+//             Ok(arg) => Some(arg.value()),
+//         }
+//     }};
+// }
+
+macro_rules! obj_field_to_opt_slice {
     ($cx:expr, $obj:expr, $field:expr) => {{
-        match $obj.get($cx, $field)?.downcast::<JsString>().or_throw($cx) {
+        match $obj.get($cx, $field)?.downcast::<JsArrayBuffer>().or_throw($cx) {
             Err(_) => None,
-            Ok(arg) => Some(arg.value()),
+            Ok(arg) => Some($cx.borrow(&arg, |d| d.as_slice::<u8>()).to_vec())
         }
     }};
 }
@@ -82,13 +91,13 @@ macro_rules! cast_to_slice {
     }};
 }
 
-macro_rules! cast_to_string {
-    ($cx:expr, $obj:expr) => {{
-        $obj.downcast::<JsString>()
-            .unwrap_or($cx.string(""))
-            .value()
-    }};
-}
+// macro_rules! cast_to_string {
+//     ($cx:expr, $obj:expr) => {{
+//         $obj.downcast::<JsString>()
+//             .unwrap_or($cx.string(""))
+//             .value()
+//     }};
+// }
 
 macro_rules! cast_to_number {
     ($cx:expr, $obj:expr) => {
@@ -106,8 +115,8 @@ macro_rules! handle_err {
 
 macro_rules! obj_field_to_field_elem {
     ($cx:expr, $d:expr) => {{
-        let m = cast_to_string!($cx, $d);
-        SignatureMessage::hash(m.as_bytes())
+        let m = cast_to_slice!($cx, $d);
+        SignatureMessage::hash(m)
     }};
 }
 

--- a/native/tests/vectors.rs
+++ b/native/tests/vectors.rs
@@ -251,8 +251,6 @@ fn proof_with_8_messages() {
     let res = Verifier::verify_signature_pok(&pr, &sig_pok, &nonce);
 
     assert!(res.is_ok());
-    // let proved_messages = res.unwrap();
-    // assert_eq!(proved_messages, vec![SignatureMessage::from_msg_hash(b"Message9")])
 }
 
 #[test]
@@ -296,11 +294,6 @@ fn print() {
     let res = Verifier::verify_signature_pok(&proof_request, &proof, &nonce);
 
     assert!(res.is_ok());
-    // let proved_messages = res.unwrap();
-
-    // proof_request.revealed_messages = BTreeSet::new();
-    // proof_request.revealed_messages.insert(1);
-    // proof.revealed_messages = vec![SignatureMessage::from_msg_hash(b"Message2")];
 }
 
 fn get_public_key(key: &str) -> DeterministicPublicKey {

--- a/native/tests/vectors.rs
+++ b/native/tests/vectors.rs
@@ -257,23 +257,19 @@ fn proof_with_8_messages() {
 
 #[test]
 fn print() {
-    let (dpk, sk) = DeterministicPublicKey::new(Some(KeyGenOption::UseSeed(base64::decode("H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=").unwrap())));
-    println!("sk  = {}", base64::encode(sk.to_bytes_compressed_form().as_ref()));
-    println!("dpk = {}", base64::encode(dpk.to_bytes_compressed_form().as_ref()));
-    let messages: Vec<SignatureMessage> = ["KNK0ITRAF+NrGg=="].iter().map(|m| SignatureMessage::hash(m.as_bytes())).collect();
+    let sk = SecretKey::try_from(base64::decode(SECRET_KEY).unwrap()).unwrap();
+    let dpk = DeterministicPublicKey::try_from(base64::decode(PUBLIC_KEY).unwrap()).unwrap();
+    let messages: Vec<SignatureMessage> = ["KnYAbm0fw3mlUA=="].iter().map(|m| SignatureMessage::hash(m.as_bytes())).collect();
     let pk = dpk.to_public_key(messages.len()).unwrap();
     let sig = Signature::new(messages.as_slice(), &sk, &pk).unwrap();
     println!("pk  = {}", base64::encode(pk.to_bytes_compressed_form()));
     println!("sig = {}", base64::encode(sig.to_bytes_compressed_form().as_ref()));
-    let nonce = ProofNonce::hash(b"v3bb/Mz+JajUdiM2URfZYcPuqxw=");
+    let nonce = ProofNonce::hash(b"I03DvFXcpVdOPuOiyXgcBf4voAA=");
     let proof_request = Verifier::new_proof_request(&[0], &pk).unwrap();
 
     // Sends `proof_request` and `nonce` to the prover
     let proof_messages = vec![
         pm_revealed_raw!(messages[0]),
-        // pm_revealed_raw!(messages[1]),
-        // pm_revealed_raw!(messages[2]),
-    //     pm_hidden!(b"Message4"),
     ];
 
     let pok =

--- a/src/bbsSignature.ts
+++ b/src/bbsSignature.ts
@@ -45,12 +45,13 @@ export const BBS_SIGNATURE_LENGTH = 112;
  */
 export const sign = (request: BbsSignRequest): Uint8Array => {
   const { keyPair, messages } = request;
+  const messageBuffers = messages.map((_) => _.buffer);
   try {
     return new Uint8Array(
       bbs.bbs_sign({
         publicKey: keyPair.publicKey.buffer,
         secretKey: keyPair.secretKey?.buffer as ArrayBuffer,
-        messages,
+        messages: messageBuffers,
       })
     );
   } catch {
@@ -67,12 +68,13 @@ export const sign = (request: BbsSignRequest): Uint8Array => {
 export const blsSign = (request: BlsBbsSignRequest): Uint8Array => {
   const { keyPair, messages } = request;
   const bbsKeyPair = bls12381toBbs({ keyPair, messageCount: messages.length });
+  const messageBuffers = messages.map((_) => _.buffer);
   try {
     return new Uint8Array(
       bbs.bbs_sign({
         publicKey: bbsKeyPair.publicKey.buffer,
         secretKey: bbsKeyPair.secretKey?.buffer as ArrayBuffer,
-        messages,
+        messages: messageBuffers,
       })
     );
   } catch {
@@ -88,11 +90,12 @@ export const blsSign = (request: BlsBbsSignRequest): Uint8Array => {
  */
 export const verify = (request: BbsVerifyRequest): BbsVerifyResult => {
   const { publicKey, signature, messages } = request;
+  const messageBuffers = messages.map((_) => _.buffer);
   try {
     const result = bbs.bbs_verify({
       publicKey: publicKey.buffer,
       signature: signature.buffer,
-      messages,
+      messages: messageBuffers,
     });
     return { verified: result };
   } catch (ex) {
@@ -110,10 +113,11 @@ export const blsVerify = (request: BlsBbsVerifyRequest): BbsVerifyResult => {
   try {
     const { publicKey, signature, messages } = request;
     const bbsKeyPair = bls12381toBbs({ keyPair: { publicKey }, messageCount: messages.length });
+    const messageBuffers = messages.map((_) => _.buffer);
     const result = bbs.bbs_verify({
       publicKey: bbsKeyPair.publicKey.buffer,
       signature: signature.buffer,
-      messages,
+      messages: messageBuffers,
     });
     return { verified: result };
   } catch (ex) {
@@ -129,14 +133,15 @@ export const blsVerify = (request: BlsBbsVerifyRequest): BbsVerifyResult => {
  */
 export const createProof = (request: BbsCreateProofRequest): Uint8Array => {
   const { publicKey, signature, messages, nonce, revealed } = request;
+  const messageBuffers = messages.map((_) => _.buffer);
   try {
     return new Uint8Array(
       bbs.bbs_create_proof({
-        nonce,
+        nonce: nonce.buffer,
         revealed,
         publicKey: publicKey.buffer,
         signature: signature.buffer,
-        messages,
+        messages: messageBuffers,
       })
     );
   } catch (ex) {
@@ -153,14 +158,15 @@ export const createProof = (request: BbsCreateProofRequest): Uint8Array => {
 export const blsCreateProof = (request: BbsCreateProofRequest): Uint8Array => {
   const { publicKey, signature, messages, nonce, revealed } = request;
   const bbsKeyPair = bls12381toBbs({ keyPair: { publicKey }, messageCount: messages.length });
+  const messageBuffers = messages.map((_) => _.buffer);
   try {
     return new Uint8Array(
       bbs.bbs_create_proof({
-        nonce,
+        nonce: nonce.buffer,
         revealed,
         publicKey: bbsKeyPair.publicKey.buffer,
         signature: signature.buffer,
-        messages,
+        messages: messageBuffers,
       })
     );
   } catch (ex) {
@@ -176,12 +182,13 @@ export const blsCreateProof = (request: BbsCreateProofRequest): Uint8Array => {
  */
 export const verifyProof = (request: BbsVerifyProofRequest): BbsVerifyResult => {
   const { publicKey, proof, messages, nonce } = request;
+  const messageBuffers = messages.map((_) => _.buffer);
   try {
     const result = bbs.bbs_verify_proof({
-      nonce,
+      nonce: nonce.buffer,
       publicKey: publicKey.buffer,
       proof: proof.buffer,
-      messages,
+      messages: messageBuffers,
     });
     return { verified: result };
   } catch (ex) {
@@ -198,11 +205,12 @@ export const verifyProof = (request: BbsVerifyProofRequest): BbsVerifyResult => 
 export const blsVerifyProof = (request: BbsVerifyProofRequest): BbsVerifyResult => {
   try {
     const { publicKey, proof, messages, nonce } = request;
+    const messageBuffers = messages.map((_) => _.buffer);
     const result = bbs.bls_verify_proof({
-      nonce,
+      nonce: nonce.buffer,
       publicKey: publicKey.buffer,
       proof: proof.buffer,
-      messages,
+      messages: messageBuffers,
     });
     return { verified: result };
   } catch (ex) {
@@ -218,10 +226,11 @@ export const blsVerifyProof = (request: BbsVerifyProofRequest): BbsVerifyResult 
  */
 export const commitmentForBlindSignRequest = (request: BbsBlindSignContextRequest): BbsBlindSignContext => {
   const { publicKey, messages, hidden, nonce } = request;
+  const messageBuffers = messages.map((_) => _.buffer);
   try {
     return bbs.bbs_blind_signature_commitment({
       publicKey: publicKey.buffer,
-      messages,
+      messages: messageBuffers,
       hidden,
       nonce,
     });
@@ -256,12 +265,13 @@ export const verifyBlindSignContext = (request: BbsVerifyBlindSignContextRequest
  */
 export const blindSign = (request: BbsBlindSignRequest): Uint8Array => {
   const { commitment, secretKey, messages } = request;
+  const messageBuffers = messages.map((_) => _.buffer);
   try {
     return new Uint8Array(
       bbs.bbs_blind_sign({
         commitment: commitment.buffer,
         secretKey: secretKey.buffer,
-        messages,
+        messages: messageBuffers,
       })
     );
   } catch (ex) {

--- a/src/types/BbsBlindSignContextRequest.ts
+++ b/src/types/BbsBlindSignContextRequest.ts
@@ -27,9 +27,9 @@ export interface BbsBlindSignContextRequest {
   /**
    * A nonce for the resulting proof
    */
-  readonly nonce: string;
+  readonly nonce: Uint8Array;
   /**
    * The known messages to sign
    */
-  readonly messages: readonly string[];
+  readonly messages: readonly Uint8Array[];
 }

--- a/src/types/BbsBlindSignRequest.ts
+++ b/src/types/BbsBlindSignRequest.ts
@@ -26,5 +26,5 @@ export interface BbsBlindSignRequest {
   /**
    * The known messages to sign
    */
-  readonly messages: readonly string[];
+  readonly messages: readonly Uint8Array[];
 }

--- a/src/types/BbsCreateProofRequest.ts
+++ b/src/types/BbsCreateProofRequest.ts
@@ -26,7 +26,7 @@ export interface BbsCreateProofRequest {
   /**
    * The messages that were originally signed
    */
-  readonly messages: readonly string[];
+  readonly messages: readonly Uint8Array[];
   /**
    * The zero based indicies of which messages to reveal
    */
@@ -34,5 +34,5 @@ export interface BbsCreateProofRequest {
   /**
    * A nonce for the resulting proof
    */
-  readonly nonce: string;
+  readonly nonce: Uint8Array;
 }

--- a/src/types/BbsSignRequest.ts
+++ b/src/types/BbsSignRequest.ts
@@ -24,5 +24,5 @@ export interface BbsSignRequest {
   /**
    * Messages to sign
    */
-  readonly messages: readonly string[];
+  readonly messages: readonly Uint8Array[];
 }

--- a/src/types/BbsVerifyBlindSignContextRequest.ts
+++ b/src/types/BbsVerifyBlindSignContextRequest.ts
@@ -38,5 +38,5 @@ export interface BbsVerifyBlindSignContextRequest {
   /**
    * A nonce for the resulting proof
    */
-  readonly nonce: string;
+  readonly nonce: Uint8Array;
 }

--- a/src/types/BbsVerifyProofRequest.ts
+++ b/src/types/BbsVerifyProofRequest.ts
@@ -26,9 +26,9 @@ export interface BbsVerifyProofRequest {
   /**
    * Revealed messages to verify (TODO maybe rename this field??)
    */
-  readonly messages: readonly string[];
+  readonly messages: readonly Uint8Array[];
   /**
    * Nonce included in the proof for the un-revealed attributes (OPTIONAL)
    */
-  readonly nonce: string;
+  readonly nonce: Uint8Array;
 }

--- a/src/types/BbsVerifyRequest.ts
+++ b/src/types/BbsVerifyRequest.ts
@@ -26,5 +26,5 @@ export interface BbsVerifyRequest {
   /**
    * Messages that were signed to produce the signature
    */
-  readonly messages: readonly string[];
+  readonly messages: readonly Uint8Array[];
 }

--- a/src/types/BlsBbsSignRequest.ts
+++ b/src/types/BlsBbsSignRequest.ts
@@ -24,5 +24,5 @@ export interface BlsBbsSignRequest {
   /**
    * Messages to sign
    */
-  readonly messages: readonly string[];
+  readonly messages: readonly Uint8Array[];
 }

--- a/src/types/BlsBbsVerifyRequest.ts
+++ b/src/types/BlsBbsVerifyRequest.ts
@@ -26,5 +26,5 @@ export interface BlsBbsVerifyRequest {
   /**
    * Messages that were signed to produce the signature
    */
-  readonly messages: readonly string[];
+  readonly messages: readonly Uint8Array[];
 }


### PR DESCRIPTION
## Description

**Breaking Change**

This PR changes the public interface of the library to accept the following API elements as Uint8Array's rather than strings.

- messages: The array of messages that are being signed/validated or a proof being derived from.
- nonce: Used in create and verify derived proof.

Changes effect the following API's

- blsSign()
- sign()
- blsVerify()
- verify()
- blsCreateProof()
- createProof()
- blsVerifyProof()
- verifyProof()
- commitmentForBlindSignRequest()
- blindSign()

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.