### PR TITLE
feat: change to async based api

### DIFF
--- a/__tests__/bbsSignature/createProof.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/createProof.bbsSignature.spec.ts
@@ -17,7 +17,7 @@ import { base64Decode, stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
   describe("createProof", () => {
-    it("should create proof revealing single message from single message signature", () => {
+    it("should create proof revealing single message from single message signature", async () => {
       const messages = [stringToBytes("RmtnDBJHso5iSg==")];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pboZyjM38YgjaUBcjftZi5gb58Qz13XeRJpiuUHH06I7/1Eb8oVtIW5SGMNfKaqKhBAAAAAYPPztgxfWWw01/0SSug1oLfVuI4XUqhgyZ3rS6eTkOLjnyR3ObXb0XCD2Mfcxiv6w=="
@@ -34,12 +34,12 @@ describe("bbsSignature", () => {
         revealed: [0],
       };
 
-      const proof = createProof(request);
+      const proof = await createProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383);
     });
 
-    it("should create proof revealing all messages from multi-message signature", () => {
+    it("should create proof revealing all messages from multi-message signature", async () => {
       const messages = [
         stringToBytes("J42AxhciOVkE9w=="),
         stringToBytes("PNMnARWIHP+s2g=="),
@@ -61,12 +61,12 @@ describe("bbsSignature", () => {
         revealed: [0, 1, 2],
       };
 
-      const proof = createProof(request);
+      const proof = await createProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383); //TODO add a reason for this and some constants?
     });
 
-    it("should create proof revealing single message from multi-message signature", () => {
+    it("should create proof revealing single message from multi-message signature", async () => {
       const messages = [
         stringToBytes("J42AxhciOVkE9w=="),
         stringToBytes("PNMnARWIHP+s2g=="),
@@ -88,12 +88,12 @@ describe("bbsSignature", () => {
         revealed: [0],
       };
 
-      const proof = createProof(request);
+      const proof = await createProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(447); //TODO add a reason for this and some constants?
     });
 
-    it("should create proof revealing multiple messages from multi-message signature", () => {
+    it("should create proof revealing multiple messages from multi-message signature", async () => {
       const messages = [
         stringToBytes("J42AxhciOVkE9w=="),
         stringToBytes("PNMnARWIHP+s2g=="),
@@ -115,14 +115,14 @@ describe("bbsSignature", () => {
         revealed: [0, 2],
       };
 
-      const proof = createProof(request);
+      const proof = await createProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(415); //TODO evaluate this length properly add a reason for this and some constants?
     });
   });
 
   describe("blsCreateProof", () => {
-    it("should create proof revealing single message from single message signature", () => {
+    it("should create proof revealing single message from single message signature", async () => {
       const messages = [stringToBytes("uzAoQFqLgReidw==")];
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
@@ -139,12 +139,12 @@ describe("bbsSignature", () => {
         revealed: [0],
       };
 
-      const proof = blsCreateProof(request);
+      const proof = await blsCreateProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383);
     });
 
-    it("should create proof revealing all messages from multi-message signature", () => {
+    it("should create proof revealing all messages from multi-message signature", async () => {
       const messages = [
         stringToBytes("C+n1rPz1/tVzPg=="),
         stringToBytes("h3x8cbySqC4rLA=="),
@@ -166,12 +166,12 @@ describe("bbsSignature", () => {
         revealed: [0, 1, 2],
       };
 
-      const proof = blsCreateProof(request);
+      const proof = await blsCreateProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(383); //TODO add a reason for this and some constants?
     });
 
-    it("should create proof revealing single message from multi-message signature", () => {
+    it("should create proof revealing single message from multi-message signature", async () => {
       const messages = [
         stringToBytes("uiSKIfNoO2rMrA=="),
         stringToBytes("lMoHHrFx0LxwAw=="),
@@ -193,12 +193,12 @@ describe("bbsSignature", () => {
         revealed: [0],
       };
 
-      const proof = blsCreateProof(request);
+      const proof = await blsCreateProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(447); //TODO add a reason for this and some constants?
     });
 
-    it("should create proof revealing multiple messages from multi-message signature", () => {
+    it("should create proof revealing multiple messages from multi-message signature", async () => {
       const messages = [
         stringToBytes("uiSKIfNoO2rMrA=="),
         stringToBytes("lMoHHrFx0LxwAw=="),
@@ -220,7 +220,7 @@ describe("bbsSignature", () => {
         revealed: [0, 2],
       };
 
-      const proof = blsCreateProof(request);
+      const proof = await blsCreateProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(415); //TODO evaluate this length properly add a reason for this and some constants?
     });

--- a/__tests__/bbsSignature/sign.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/sign.bbsSignature.spec.ts
@@ -25,42 +25,51 @@ import {
 import { stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
-  const blsKeyPair = generateBls12381G2KeyPair();
-  describe("sign", () => {
-    const bbsKeyPair = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 3 });
+  let blsKeyPair: Required<BlsKeyPair>;
 
-    it("should sign a single message", () => {
-      const bbsKeyPair = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
+  beforeAll(async () => {
+    blsKeyPair = await generateBls12381G2KeyPair();
+  });
+
+  describe("sign", () => {
+    let bbsKeyPair: BbsKeyPair;
+
+    beforeAll(async () => {
+      bbsKeyPair = await bls12381toBbs({ keyPair: blsKeyPair, messageCount: 3 });
+    });
+
+    it("should sign a single message", async () => {
+      const bbsKeyPair = await bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
       const request: BbsSignRequest = {
         keyPair: bbsKeyPair,
         messages: [stringToBytes("ExampleMessage")],
       };
-      const signature = sign(request);
+      const signature = await sign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
-    it("should sign multiple messages", () => {
+    it("should sign multiple messages", async () => {
       const request: BbsSignRequest = {
         keyPair: bbsKeyPair,
         messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
       };
-      const signature = sign(request);
+      const signature = await sign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
-    it("should sign multiple messages when public key supports more", () => {
+    it("should sign multiple messages when public key supports more", async () => {
       const request: BbsSignRequest = {
         keyPair: bbsKeyPair,
         messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage")],
       };
-      const signature = sign(request);
+      const signature = await sign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
-    it("should throw error if secret key not present", () => {
+    it("should throw error if secret key not present", async () => {
       const bbsKey: BbsKeyPair = {
         publicKey: bbsKeyPair.publicKey,
         messageCount: bbsKeyPair.messageCount,
@@ -69,41 +78,41 @@ describe("bbsSignature", () => {
         keyPair: bbsKey,
         messages: [stringToBytes("ExampleMessage")],
       };
-      expect(() => sign(request)).toThrowError("Failed to sign");
+      await expect(sign(request)).rejects.toThrowError("Failed to sign");
     });
 
-    it("should throw error if public key does not support message number", () => {
-      const bbsKeyPair = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
+    it("should throw error if public key does not support message number", async () => {
+      const bbsKeyPair = await bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
       const request: BbsSignRequest = {
         keyPair: bbsKeyPair,
         messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage")],
       };
-      expect(() => sign(request)).toThrowError("Failed to sign");
+      await expect(sign(request)).rejects.toThrowError("Failed to sign");
     });
   });
 
   describe("blsSign", () => {
-    it("should sign a single message", () => {
+    it("should sign a single message", async () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
         messages: [stringToBytes("ExampleMessage")],
       };
-      const signature = blsSign(request);
+      const signature = await blsSign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
-    it("should sign multiple messages", () => {
+    it("should sign multiple messages", async () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
         messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
       };
-      const signature = blsSign(request);
+      const signature = await blsSign(request);
       expect(signature).toBeInstanceOf(Uint8Array);
       expect(signature.length).toEqual(BBS_SIGNATURE_LENGTH);
     });
 
-    it("should throw error if secret key not present", () => {
+    it("should throw error if secret key not present", async () => {
       const blsKey: BlsKeyPair = {
         publicKey: blsKeyPair.publicKey,
       };
@@ -111,15 +120,15 @@ describe("bbsSignature", () => {
         keyPair: blsKey,
         messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
       };
-      expect(() => blsSign(request)).toThrowError("Failed to sign");
+      await expect(blsSign(request)).rejects.toThrowError("Failed to sign");
     });
 
-    it("should throw error when messages empty", () => {
+    it("should throw error when messages empty", async () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
         messages: [],
       };
-      expect(() => blsSign(request)).toThrowError("Failed to convert key");
+      await expect(blsSign(request)).rejects.toThrowError("Failed to convert key");
     });
   });
 });

--- a/__tests__/bbsSignature/verify.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/verify.bbsSignature.spec.ts
@@ -22,46 +22,52 @@ import {
   BlsBbsSignRequest,
   blsSign,
   BlsBbsVerifyRequest,
+  BlsKeyPair,
 } from "../../src";
 import { base64Decode, stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
   describe("verify", () => {
-    const blsKeyPair = generateBls12381G2KeyPair();
-    it("should verify valid signature with a single message", () => {
-      const BbsPublicKey = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
+    let blsKeyPair: Required<BlsKeyPair>;
+
+    beforeAll(async () => {
+      blsKeyPair = await generateBls12381G2KeyPair();
+    });
+
+    it("should verify valid signature with a single message", async () => {
+      const BbsPublicKey = await bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
       const request: BbsSignRequest = {
         keyPair: BbsPublicKey,
         messages: [stringToBytes("ExampleMessage")],
       };
-      const signature = sign(request);
+      const signature = await sign(request);
       const verifyRequest: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
         messages: [stringToBytes("ExampleMessage")],
         signature,
       };
-      const result = verify(verifyRequest);
+      const result = await verify(verifyRequest);
       expect(result.verified).toBeTruthy();
     });
 
-    it("should verify valid signature with multiple messages", () => {
-      const BbsPublicKey = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 3 });
+    it("should verify valid signature with multiple messages", async () => {
+      const BbsPublicKey = await bls12381toBbs({ keyPair: blsKeyPair, messageCount: 3 });
       const request: BbsSignRequest = {
         keyPair: BbsPublicKey,
         messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
       };
-      const signature = sign(request);
+      const signature = await sign(request);
       const verifyRequest: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
         messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
         signature: signature,
       };
-      expect(verify(verifyRequest).verified).toBeTruthy();
+      expect((await verify(verifyRequest)).verified).toBeTruthy();
     });
 
-    it("should not verify valid signature with wrong single message", () => {
+    it("should not verify valid signature with wrong single message", async () => {
       const messages = [stringToBytes("BadMessage")];
-      const BbsPublicKey = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
+      const BbsPublicKey = await bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
       const verifyRequest: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
         messages,
@@ -69,12 +75,12 @@ describe("bbsSignature", () => {
           "kTV8dar9xLWQZ5EzaWYqTRmgA6dw6wcrUw5c///crRD2QQPXX9Di+lgCPCXAA5D8Pytuh6bNSx6k4NZTR9KfSNdaejKl2zTU9poRfzZ2SIskdgSHTZ2y7jLm/UEGKsAs3tticBVj1Pm2GNhQI/OlXQ=="
         ),
       };
-      expect(verify(verifyRequest).verified).toBeFalsy();
+      expect((await verify(verifyRequest)).verified).toBeFalsy();
     });
 
-    it("should not verify valid signature with wrong messages", () => {
+    it("should not verify valid signature with wrong messages", async () => {
       const messages = [stringToBytes("BadMessage"), stringToBytes("BadMessage"), stringToBytes("BadMessage")];
-      const BbsPublicKey = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 3 });
+      const BbsPublicKey = await bls12381toBbs({ keyPair: blsKeyPair, messageCount: 3 });
       const verifyRequest: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
         messages,
@@ -82,11 +88,11 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(verify(verifyRequest).verified).toBeFalsy();
+      expect((await verify(verifyRequest)).verified).toBeFalsy();
     });
 
-    it("should throw error when messages empty", () => {
-      const BbsPublicKey = bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
+    it("should throw error when messages empty", async () => {
+      const BbsPublicKey = await bls12381toBbs({ keyPair: blsKeyPair, messageCount: 1 });
       const request: BbsVerifyRequest = {
         publicKey: BbsPublicKey.publicKey,
         messages: [],
@@ -94,10 +100,10 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(verify(request).verified).toBeFalsy();
+      expect((await verify(request)).verified).toBeFalsy();
     });
 
-    it("should throw error when public key invalid length", () => {
+    it("should throw error when public key invalid length", async () => {
       const request: BbsVerifyRequest = {
         publicKey: new Uint8Array(20),
         messages: [],
@@ -105,40 +111,48 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(verify(request).verified).toBeFalsy();
+      const result = await verify(request);
+      expect(result.verified).toBeFalsy();
     });
   });
   describe("blsVerify", () => {
-    const blsKeyPair = generateBls12381G2KeyPair();
-    it("should verify valid signature with a single message", () => {
+    let blsKeyPair: Required<BlsKeyPair>;
+
+    beforeAll(async () => {
+      blsKeyPair = await generateBls12381G2KeyPair();
+    });
+
+    it("should verify valid signature with a single message", async () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
         messages: [stringToBytes("ExampleMessage")],
       };
-      const signature = blsSign(request);
+      const signature = await blsSign(request);
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
         messages: [stringToBytes("ExampleMessage")],
         signature,
       };
-      expect(blsVerify(verifyRequest).verified).toBeTruthy();
+      const result = await blsVerify(verifyRequest);
+      expect(result.verified).toBeTruthy();
     });
 
-    it("should verify valid signature with multiple messages", () => {
+    it("should verify valid signature with multiple messages", async () => {
       const request: BlsBbsSignRequest = {
         keyPair: blsKeyPair,
         messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
       };
-      const signature = blsSign(request);
+      const signature = await blsSign(request);
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
         messages: [stringToBytes("ExampleMessage"), stringToBytes("ExampleMessage2"), stringToBytes("ExampleMessage3")],
         signature,
       };
-      expect(blsVerify(verifyRequest).verified).toBeTruthy();
+      const result = await blsVerify(verifyRequest);
+      expect(result.verified).toBeTruthy();
     });
 
-    it("should not verify valid signature with wrong single message", () => {
+    it("should not verify valid signature with wrong single message", async () => {
       const messages = [stringToBytes("BadMessage")];
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
@@ -147,10 +161,11 @@ describe("bbsSignature", () => {
           "kTV8dar9xLWQZ5EzaWYqTRmgA6dw6wcrUw5c///crRD2QQPXX9Di+lgCPCXAA5D8Pytuh6bNSx6k4NZTR9KfSNdaejKl2zTU9poRfzZ2SIskdgSHTZ2y7jLm/UEGKsAs3tticBVj1Pm2GNhQI/OlXQ=="
         ),
       };
-      expect(blsVerify(verifyRequest).verified).toBeFalsy();
+      const result = await blsVerify(verifyRequest);
+      expect(result.verified).toBeFalsy();
     });
 
-    it("should not verify valid signature with wrong messages", () => {
+    it("should not verify valid signature with wrong messages", async () => {
       const messages = [stringToBytes("BadMessage"), stringToBytes("BadMessage"), stringToBytes("BadMessage")];
       const verifyRequest: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
@@ -159,10 +174,11 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(verify(verifyRequest).verified).toBeFalsy();
+      const result = await verify(verifyRequest);
+      expect(result.verified).toBeFalsy();
     });
 
-    it("should not verify when messages empty", () => {
+    it("should not verify when messages empty", async () => {
       const request: BlsBbsVerifyRequest = {
         publicKey: blsKeyPair.publicKey,
         messages: [],
@@ -170,10 +186,11 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(blsVerify(request).verified).toBeFalsy();
+      const result = await blsVerify(request);
+      expect(result.verified).toBeFalsy();
     });
 
-    it("should not verify when public key invalid length", () => {
+    it("should not verify when public key invalid length", async () => {
       const request: BlsBbsVerifyRequest = {
         publicKey: new Uint8Array(20),
         messages: [],
@@ -181,7 +198,8 @@ describe("bbsSignature", () => {
           "jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ=="
         ),
       };
-      expect(blsVerify(request).verified).toBeFalsy();
+      const result = await blsVerify(request);
+      expect(result.verified).toBeFalsy();
     });
   });
 });

--- a/__tests__/bbsSignature/verifyProof.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/verifyProof.bbsSignature.spec.ts
@@ -17,7 +17,7 @@ import { base64Decode, stringToBytes } from "../utilities";
 
 describe("bbsSignature", () => {
   describe("verifyProof", () => {
-    it("should verify proof with all messages revealed from single message signature", () => {
+    it("should verify proof with all messages revealed from single message signature", async () => {
       const messages = [stringToBytes("KNK0ITRAF+NrGg==")];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pboZyjM38YgjaUBcjftZi5gb58Qz13XeRJpiuUHH06I7/1Eb8oVtIW5SGMNfKaqKhBAAAAAYPPztgxfWWw01/0SSug1oLfVuI4XUqhgyZ3rS6eTkOLjnyR3ObXb0XCD2Mfcxiv6w=="
@@ -33,10 +33,11 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("v3bb/Mz+JajUdiM2URfZYcPuqxw="),
       };
 
-      expect(verifyProof(request).verified).toBeTruthy();
+      const result = await verifyProof(request);
+      expect(result.verified).toBeTruthy();
     });
 
-    it("should verify proof with all messages revealed from multi message signature", () => {
+    it("should verify proof with all messages revealed from multi message signature", async () => {
       const messages = [
         stringToBytes("BVB6lAn912sz9Q=="),
         stringToBytes("b45VqRkIo5R5Zw=="),
@@ -56,10 +57,11 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("dVPpzuQtJVAZzAw73beWiXLtoT4="),
       };
 
-      expect(verifyProof(request).verified).toBeTruthy();
+      const result = await verifyProof(request);
+      expect(result.verified).toBeTruthy();
     });
 
-    it("should verify proof with one message revealed from multi-message signature", () => {
+    it("should verify proof with one message revealed from multi-message signature", async () => {
       const messages = [
         stringToBytes("+FxEv3VLcNZ8sA=="),
         stringToBytes("eI2RcRExnbP8hw=="),
@@ -81,10 +83,11 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("NoWZhtX+u1wWLtUfPMmku1FtU2I="),
       };
 
-      expect(verifyProof(request).verified).toBeTruthy();
+      const result = await verifyProof(request);
+      expect(result.verified).toBeTruthy();
     });
 
-    it("should not verify with bad nonce", () => {
+    it("should not verify with bad nonce", async () => {
       const messages = [stringToBytes("KNK0ITRAF+NrGg==")];
       const bbsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pboZyjM38YgjaUBcjftZi5gb58Qz13XeRJpiuUHH06I7/1Eb8oVtIW5SGMNfKaqKhBAAAAAYPPztgxfWWw01/0SSug1oLfVuI4XUqhgyZ3rS6eTkOLjnyR3ObXb0XCD2Mfcxiv6w=="
@@ -100,10 +103,11 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("bad"),
       };
 
-      expect(verifyProof(request).verified).toBeFalsy();
+      const result = await verifyProof(request);
+      expect(result.verified).toBeFalsy();
     });
 
-    it("should not verify with a message that wasn't signed", () => {
+    it("should not verify with a message that wasn't signed", async () => {
       // Expects messages to be ["Message1", "Message2", "Message3", "Message4"];
       const messages = [
         stringToBytes("BadMessage1"),
@@ -124,11 +128,12 @@ describe("bbsSignature", () => {
         messages,
         nonce: stringToBytes("0123456789"),
       };
-      expect(verifyProof(request).verified).toBeFalsy();
+      const result = await verifyProof(request);
+      expect(result.verified).toBeFalsy();
     });
   });
 
-  it("should not verify with revealed message that was supposed to be hidden", () => {
+  it("should not verify with revealed message that was supposed to be hidden", async () => {
     const messages = [
       stringToBytes("Message1"),
       stringToBytes("Message2"),
@@ -150,7 +155,7 @@ describe("bbsSignature", () => {
       revealed: [0],
       nonce,
     };
-    const proof = createProof(proofRequest);
+    const proof = await createProof(proofRequest);
 
     let proofMessages = [stringToBytes("BadMessage9")];
     let request = {
@@ -162,7 +167,8 @@ describe("bbsSignature", () => {
       revealed: [0],
     };
 
-    expect(verifyProof(request).verified).toBeFalsy();
+    let result = await verifyProof(request);
+    expect(result.verified).toBeFalsy();
 
     proofMessages = [stringToBytes("Message1")];
     request = {
@@ -173,11 +179,12 @@ describe("bbsSignature", () => {
       nonce,
       revealed: [0],
     };
-    expect(verifyProof(request).verified).toBeTruthy();
+    result = await verifyProof(request);
+    expect(result.verified).toBeTruthy();
   });
 
   describe("blsVerifyProof", () => {
-    it("should verify proof with all messages revealed from single message signature", () => {
+    it("should verify proof with all messages revealed from single message signature", async () => {
       const messages = [stringToBytes("KnYAbm0fw3mlUA==")];
       const blsPublicKey = base64Decode(
         "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
@@ -193,10 +200,11 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("4OS3nji2HNReo3QPHrdlxjOf8gc="),
       };
 
-      expect(blsVerifyProof(request).verified).toBeTruthy();
+      const result = await blsVerifyProof(request);
+      expect(result.verified).toBeTruthy();
     });
 
-    it("should verify proof with all messages revealed from multi message signature", () => {
+    it("should verify proof with all messages revealed from multi message signature", async () => {
       const messages = [
         stringToBytes("ODLpUKee6nyz7g=="),
         stringToBytes("v2zteJajIyIh5Q=="),
@@ -216,10 +224,11 @@ describe("bbsSignature", () => {
         nonce: stringToBytes("ujMevaaq2n7Cg3ZLzXktqT/WRgM="),
       };
 
-      expect(blsVerifyProof(request).verified).toBeTruthy();
+      const result = await blsVerifyProof(request);
+      expect(result.verified).toBeTruthy();
     });
 
-    it("should verify proof with one message revealed from multi-message signature", () => {
+    it("should verify proof with one message revealed from multi-message signature", async () => {
       const messages = [
         stringToBytes("8NhsJO/MKxO74A=="),
         stringToBytes("0noLBcl29ASJ2w=="),
@@ -240,11 +249,11 @@ describe("bbsSignature", () => {
         messages: revealedMessages,
         nonce: stringToBytes("I03DvFXcpVdOPuOiyXgcBf4voAA="),
       };
-
-      expect(blsVerifyProof(request).verified).toBeTruthy();
+      const result = await blsVerifyProof(request);
+      expect(result.verified).toBeTruthy();
     });
 
-    it("should not verify with bad nonce", () => {
+    it("should not verify with bad nonce", async () => {
       const messages = [stringToBytes("KnYAbm0fw3mlUA==")];
       const blsPublicKey = base64Decode(
         "x45gpyN9ryZHcdlbJCKrM6WAPI6BggO97nmTcimnXwFA7AeMf54x7atqH0BvxV4UA3f7DcWHpq0HEytVwin7pd/AZXjexfTynNgUgVdd/xkcRdwKCgBMnEx5R7csAGVm"
@@ -259,8 +268,8 @@ describe("bbsSignature", () => {
         messages,
         nonce: stringToBytes("bad"),
       };
-
-      expect(blsVerifyProof(request).verified).toBeFalsy();
+      const result = await blsVerifyProof(request);
+      expect(result.verified).toBeFalsy();
     });
   });
 });

--- a/__tests__/bls12381.spec.ts
+++ b/__tests__/bls12381.spec.ts
@@ -37,8 +37,8 @@ describe("bls12381", () => {
       publicKeyLength: DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH,
     },
   ].forEach((value) => {
-    it(`should be able to generate a key pair in ${value.field} field`, () => {
-      const result = value.generateKeyFn();
+    it(`should be able to generate a key pair in ${value.field} field`, async () => {
+      const result = await value.generateKeyFn();
       expect(result).toBeDefined();
       expect(result.publicKey).toBeDefined();
       expect(result.secretKey).toBeDefined();
@@ -61,9 +61,9 @@ describe("bls12381", () => {
       publicKeyLength: DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH,
     },
   ].forEach((value) => {
-    it(`should be able to generate a key pairs in ${value.field} field without seed which are random`, () => {
-      const keyPair1 = value.generateKeyFn();
-      const keyPair2 = value.generateKeyFn();
+    it(`should be able to generate a key pairs in ${value.field} field without seed which are random`, async () => {
+      const keyPair1 = await value.generateKeyFn();
+      const keyPair2 = await value.generateKeyFn();
       expect(keyPair1).toBeDefined();
       expect(keyPair2).toBeDefined();
       expect((keyPair1.secretKey as Uint8Array) === (keyPair2.secretKey as Uint8Array)).toBeFalsy();
@@ -102,8 +102,8 @@ describe("bls12381", () => {
       ),
     },
   ].forEach((value) => {
-    it(`should be able to generate a key pair with a seed in ${value.field} field`, () => {
-      const result = value.generateKeyFn(value.seed);
+    it(`should be able to generate a key pair with a seed in ${value.field} field`, async () => {
+      const result = await value.generateKeyFn(value.seed);
       expect(result.publicKey).toBeDefined();
       expect(result.secretKey).toBeDefined();
       expect(result.secretKey?.length as number).toEqual(value.secretKeyLength);
@@ -127,8 +127,8 @@ describe("bls12381", () => {
       publicKeyLength: DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH,
     },
   ].forEach((value) => {
-    it(`should be able to generate a blinded key pair in ${value.field} field`, () => {
-      const result = value.generateKeyFn();
+    it(`should be able to generate a blinded key pair in ${value.field} field`, async () => {
+      const result = await value.generateKeyFn();
       expect(result).toBeDefined();
       expect(result.publicKey).toBeDefined();
       expect(result.secretKey).toBeDefined();
@@ -169,8 +169,8 @@ describe("bls12381", () => {
       ),
     },
   ].forEach((value) => {
-    it(`should be able to generate a blinded key pair with a seed in ${value.field} field`, () => {
-      const result = value.generateKeyFn(value.seed);
+    it(`should be able to generate a blinded key pair with a seed in ${value.field} field`, async () => {
+      const result = await value.generateKeyFn(value.seed);
       expect(result.publicKey).toBeDefined();
       expect(result.secretKey).toBeDefined();
       expect(result.secretKey?.length as number).toEqual(value.secretKeyLength);

--- a/__tests__/bls12381ToBbs.spec.ts
+++ b/__tests__/bls12381ToBbs.spec.ts
@@ -14,10 +14,10 @@
 import { generateBls12381G2KeyPair, bls12381toBbs, BlsKeyPair } from "../src";
 
 describe("bls12381toBbs", () => {
-  it("should be able to convert bls12381 key pair to bbs key", () => {
-    const blsKeyPair = generateBls12381G2KeyPair();
+  it("should be able to convert bls12381 key pair to bbs key", async () => {
+    const blsKeyPair = await generateBls12381G2KeyPair();
     expect(blsKeyPair).toBeDefined();
-    const bbsKeyPair = bls12381toBbs({
+    const bbsKeyPair = await bls12381toBbs({
       keyPair: blsKeyPair,
       messageCount: 10,
     });
@@ -29,13 +29,13 @@ describe("bls12381toBbs", () => {
     expect(bbsKeyPair.secretKey).toBeInstanceOf(Uint8Array);
   });
 
-  it("should be able to convert bls12381 public key to bbs key", () => {
-    const blsKeyPair = generateBls12381G2KeyPair();
+  it("should be able to convert bls12381 public key to bbs key", async () => {
+    const blsKeyPair = await generateBls12381G2KeyPair();
     expect(blsKeyPair).toBeDefined();
     const blsPublicKey: BlsKeyPair = {
       publicKey: blsKeyPair.publicKey,
     };
-    const bbsKeyPair = bls12381toBbs({
+    const bbsKeyPair = await bls12381toBbs({
       keyPair: blsPublicKey,
       messageCount: 10,
     });
@@ -47,15 +47,15 @@ describe("bls12381toBbs", () => {
     expect(bbsKeyPair.publicKey).toBeInstanceOf(Uint8Array);
   });
 
-  it("should throw error when message count 0", () => {
-    const blsKeyPair = generateBls12381G2KeyPair();
+  it("should throw error when message count 0", async () => {
+    const blsKeyPair = await generateBls12381G2KeyPair();
     expect(blsKeyPair).toBeDefined();
 
-    expect(() =>
+    await expect(
       bls12381toBbs({
         keyPair: blsKeyPair,
         messageCount: 0,
       })
-    ).toThrowError("Failed to convert key");
+    ).rejects.toThrowError("Failed to convert key");
   });
 });

--- a/src/bbsSignature.ts
+++ b/src/bbsSignature.ts
@@ -45,7 +45,7 @@ export const BBS_SIGNATURE_LENGTH = 112;
  *
  * @returns The raw signature value
  */
-export const sign = (request: BbsSignRequest): Uint8Array => {
+export const sign = async (request: BbsSignRequest): Promise<Uint8Array> => {
   const { keyPair, messages } = request;
   const messageBuffers = messages.map((_) => _.buffer);
   try {
@@ -67,9 +67,9 @@ export const sign = (request: BbsSignRequest): Uint8Array => {
  *
  * @returns The raw signature value
  */
-export const blsSign = (request: BlsBbsSignRequest): Uint8Array => {
+export const blsSign = async (request: BlsBbsSignRequest): Promise<Uint8Array> => {
   const { keyPair, messages } = request;
-  const bbsKeyPair = bls12381toBbs({ keyPair, messageCount: messages.length });
+  const bbsKeyPair = await bls12381toBbs({ keyPair, messageCount: messages.length });
   const messageBuffers = messages.map((_) => _.buffer);
   try {
     return new Uint8Array(
@@ -90,7 +90,7 @@ export const blsSign = (request: BlsBbsSignRequest): Uint8Array => {
  *
  * @returns A result indicating if the signature was verified
  */
-export const verify = (request: BbsVerifyRequest): BbsVerifyResult => {
+export const verify = async (request: BbsVerifyRequest): Promise<BbsVerifyResult> => {
   const { publicKey, signature, messages } = request;
   const messageBuffers = messages.map((_) => _.buffer);
   try {
@@ -111,10 +111,10 @@ export const verify = (request: BbsVerifyRequest): BbsVerifyResult => {
  *
  * @returns A result indicating if the signature was verified
  */
-export const blsVerify = (request: BlsBbsVerifyRequest): BbsVerifyResult => {
+export const blsVerify = async (request: BlsBbsVerifyRequest): Promise<BbsVerifyResult> => {
   try {
     const { publicKey, signature, messages } = request;
-    const bbsKeyPair = bls12381toBbs({ keyPair: { publicKey }, messageCount: messages.length });
+    const bbsKeyPair = await bls12381toBbs({ keyPair: { publicKey }, messageCount: messages.length });
     const messageBuffers = messages.map((_) => _.buffer);
     const result = bbs.bbs_verify({
       publicKey: bbsKeyPair.publicKey.buffer,
@@ -133,7 +133,7 @@ export const blsVerify = (request: BlsBbsVerifyRequest): BbsVerifyResult => {
  *
  * @returns The raw proof value
  */
-export const createProof = (request: BbsCreateProofRequest): Uint8Array => {
+export const createProof = async (request: BbsCreateProofRequest): Promise<Uint8Array> => {
   const { publicKey, signature, messages, nonce, revealed } = request;
   const messageBuffers = messages.map((_) => _.buffer);
   try {
@@ -157,9 +157,9 @@ export const createProof = (request: BbsCreateProofRequest): Uint8Array => {
  *
  * @returns The raw proof value
  */
-export const blsCreateProof = (request: BbsCreateProofRequest): Uint8Array => {
+export const blsCreateProof = async (request: BbsCreateProofRequest): Promise<Uint8Array> => {
   const { publicKey, signature, messages, nonce, revealed } = request;
-  const bbsKeyPair = bls12381toBbs({ keyPair: { publicKey }, messageCount: messages.length });
+  const bbsKeyPair = await bls12381toBbs({ keyPair: { publicKey }, messageCount: messages.length });
   const messageBuffers = messages.map((_) => _.buffer);
   try {
     return new Uint8Array(
@@ -182,7 +182,7 @@ export const blsCreateProof = (request: BbsCreateProofRequest): Uint8Array => {
  *
  * @returns A result indicating if the proof was verified
  */
-export const verifyProof = (request: BbsVerifyProofRequest): BbsVerifyResult => {
+export const verifyProof = async (request: BbsVerifyProofRequest): Promise<BbsVerifyResult> => {
   const { publicKey, proof, messages, nonce } = request;
   const messageBuffers = messages.map((_) => _.buffer);
   try {
@@ -204,7 +204,7 @@ export const verifyProof = (request: BbsVerifyProofRequest): BbsVerifyResult => 
  *
  * @returns A result indicating if the proof was verified
  */
-export const blsVerifyProof = (request: BbsVerifyProofRequest): BbsVerifyResult => {
+export const blsVerifyProof = async (request: BbsVerifyProofRequest): Promise<BbsVerifyResult> => {
   try {
     const { publicKey, proof, messages, nonce } = request;
     const messageBuffers = messages.map((_) => _.buffer);
@@ -226,7 +226,9 @@ export const blsVerifyProof = (request: BbsVerifyProofRequest): BbsVerifyResult 
  *
  * @returns A commitment context
  */
-export const commitmentForBlindSignRequest = (request: BbsBlindSignContextRequest): BbsBlindSignContext => {
+export const commitmentForBlindSignRequest = async (
+  request: BbsBlindSignContextRequest
+): Promise<BbsBlindSignContext> => {
   const { publicKey, messages, hidden, nonce } = request;
   const messageBuffers = messages.map((_) => _.buffer);
   try {
@@ -247,7 +249,7 @@ export const commitmentForBlindSignRequest = (request: BbsBlindSignContextReques
  *
  * @returns A boolean indicating if the context was verified
  */
-export const verifyBlindSignContext = (request: BbsVerifyBlindSignContextRequest): boolean => {
+export const verifyBlindSignContext = async (request: BbsVerifyBlindSignContextRequest): Promise<boolean> => {
   const { commitment, proofOfHiddenMessages, challengeHash, publicKey, blinded, nonce } = request;
   return bbs.bbs_verify_blind_signature_proof({
     commitment: commitment.buffer,
@@ -265,7 +267,7 @@ export const verifyBlindSignContext = (request: BbsVerifyBlindSignContextRequest
  *
  * @returns The raw signature value
  */
-export const blindSign = (request: BbsBlindSignRequest): Uint8Array => {
+export const blindSign = async (request: BbsBlindSignRequest): Promise<Uint8Array> => {
   const { commitment, secretKey, messages } = request;
   const messageBuffers = messages.map((_) => _.buffer);
   try {

--- a/src/bls12381.ts
+++ b/src/bls12381.ts
@@ -27,7 +27,7 @@ const bbs = require(path.resolve(path.join(__dirname, "../native/index.node")));
  *
  * @returns A BlsKeyPair
  */
-export const generateBls12381G1KeyPair = (seed?: Uint8Array): BlsKeyPair => {
+export const generateBls12381G1KeyPair = async (seed?: Uint8Array): Promise<Required<BlsKeyPair>> => {
   const result = seed ? bbs.bls_generate_g1_key(seed?.buffer) : bbs.bls_generate_g1_key();
   return {
     publicKey: new Uint8Array(result.publicKey),
@@ -42,7 +42,7 @@ export const generateBls12381G1KeyPair = (seed?: Uint8Array): BlsKeyPair => {
  *
  * @returns A BlindedBlsKeyPair
  */
-export const generateBlindedBls12381G1KeyPair = (seed?: Uint8Array): BlindedBlsKeyPair => {
+export const generateBlindedBls12381G1KeyPair = async (seed?: Uint8Array): Promise<Required<BlindedBlsKeyPair>> => {
   const result = seed ? bbs.bls_generate_blinded_g1_key(seed?.buffer) : bbs.bls_generate_blinded_g1_key();
   return {
     publicKey: new Uint8Array(result.publicKey),
@@ -57,7 +57,7 @@ export const generateBlindedBls12381G1KeyPair = (seed?: Uint8Array): BlindedBlsK
  *
  * @returns A BlsKeyPair
  */
-export const generateBls12381G2KeyPair = (seed?: Uint8Array): BlsKeyPair => {
+export const generateBls12381G2KeyPair = async (seed?: Uint8Array): Promise<Required<BlsKeyPair>> => {
   const result = seed ? bbs.bls_generate_g2_key(seed?.buffer) : bbs.bls_generate_g2_key();
   return {
     publicKey: new Uint8Array(result.publicKey),
@@ -72,7 +72,7 @@ export const generateBls12381G2KeyPair = (seed?: Uint8Array): BlsKeyPair => {
  *
  * @returns A BlindedBlsKeyPair
  */
-export const generateBlindedBls12381G2KeyPair = (seed?: Uint8Array): BlindedBlsKeyPair => {
+export const generateBlindedBls12381G2KeyPair = async (seed?: Uint8Array): Promise<Required<BlindedBlsKeyPair>> => {
   const result = seed ? bbs.bls_generate_blinded_g2_key(seed?.buffer) : bbs.bls_generate_blinded_g2_key();
   return {
     publicKey: new Uint8Array(result.publicKey),

--- a/src/bls12381toBbs.ts
+++ b/src/bls12381toBbs.ts
@@ -27,28 +27,17 @@ const bbs = require(path.resolve(path.join(__dirname, "../native/index.node")));
  *
  * @returns A BbsKeyPair
  */
-export const bls12381toBbs = (request: Bls12381ToBbsRequest): BbsKeyPair => {
+export const bls12381toBbs = async (request: Bls12381ToBbsRequest): Promise<BbsKeyPair> => {
   try {
-    if (request.keyPair.secretKey) {
-      const result = bbs.bls_secret_key_to_bbs_key({
-        secretKey: request.keyPair.secretKey.buffer,
-        messageCount: request.messageCount,
-      });
-      return {
-        secretKey: request.keyPair.secretKey,
-        publicKey: new Uint8Array(result),
-        messageCount: request.messageCount,
-      };
-    } else {
-      const result = bbs.bls_public_key_to_bbs_key({
-        publicKey: request.keyPair.publicKey.buffer,
-        messageCount: request.messageCount,
-      });
-      return {
-        publicKey: new Uint8Array(result),
-        messageCount: request.messageCount,
-      };
-    }
+    const result = bbs.bls_public_key_to_bbs_key({
+      publicKey: request.keyPair.publicKey.buffer,
+      messageCount: request.messageCount,
+    });
+    return {
+      publicKey: new Uint8Array(result),
+      secretKey: request.keyPair.secretKey,
+      messageCount: request.messageCount,
+    };
   } catch {
     throw new Error("Failed to convert key");
   }


### PR DESCRIPTION
## Description

Migrates to an asynchronous based api to maintain an interoperable public interface with other bbs-signature libraries in the TS/JS ecosystem

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

As alluded to in the description in order for TS/JS based bbs-signature libraries to have a common public interface we are shifting this API towards a promise based API.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

All API's now return a promise wrapped result

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)