### PR TITLE
docs(readme): code example does not work properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following is a short sample on how to use the API
 
 ```typescript
 import {
-  generateBls12381KeyPair,
+  generateBls12381G2KeyPair,
   blsSign,
   blsVerify,
   blsCreateProof,
@@ -57,10 +57,10 @@ import {
 } from "@mattrglobal/node-bbs-signatures";
 
 //Generate a new key pair
-const keyPair = generateBls12381KeyPair();
+const keyPair = generateBls12381G2KeyPair();
 
 //Set of messages we wish to sign
-const messages = ["message1", "message2"];
+const messages = [Uint8Array.from(Buffer.from("message1", "utf-8")), Uint8Array.from(Buffer.from("message2", "utf-8"))];
 
 //Create the signature
 const signature = blsSign({
@@ -80,7 +80,7 @@ const proof = blsCreateProof({
   signature,
   publicKey: keyPair.publicKey,
   messages,
-  nonce: "nonce",
+  nonce: Uint8Array.from(Buffer.from("nonce", "utf8")),
   revealed: [0],
 });
 
@@ -89,7 +89,7 @@ const isProofVerified = blsVerifyProof({
   proof,
   publicKey: keyPair.publicKey,
   messages: messages.slice(0, 1),
-  nonce: "nonce",
+  nonce: Uint8Array.from(Buffer.from("nonce", "utf8")),
 });
 ```
 


### PR DESCRIPTION
The library which generates `keyPair` has changed from `generateBls12381KeyPair` to `generateBls12381G2KeyPair`.
The strings need to be converted into Unit8Array Buffer. This follows github.com/mattrglobal/bbs-signatures/.

This will help the community when they first experience this repository.

This PR does not introduce a breaking change.
