### PR TITLE
build: update release process and supported env's

### DIFF
--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   build_test:
     name: Build test
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
     strategy:
       matrix:
         node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x]

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -27,5 +27,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install --frozen-lockfile
+      - run: yarn lint
       - run: yarn build
       - run: yarn test --coverage
+      - run: yarn benchmark

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -10,6 +10,16 @@ jobs:
       matrix:
         node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x]
         os: [windows-latest, macos-latest, ubuntu-latest]
+        exclude:
+          # exclude windows node 11 due to neon-sys bug
+          - os: windows-latest
+            node-version: 11.x
+          # exclude windows node 15 due to another node-gyp bug
+          - os: windows-latest
+            node-version: 15.x
+          # exclude windows node 16 due to another node-gyp bug
+          - os: windows-latest
+            node-version: 16.x
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -17,7 +27,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install --frozen-lockfile
-      - run: yarn lint
       - run: yarn build
       - run: yarn test --coverage
-      - run: yarn benchmark

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_test_publish:
     name: Build, test, and publish unstable release
-    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    if: "contains(github.event.head_commit.message, 'chore(release): publish')"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -19,6 +19,12 @@ jobs:
           # exclude windows node 11 due to neon-sys bug
           - os: windows-latest
             node-version: 11.x
+          # exclude windows node 15 due to another node-gyp bug
+          - os: windows-latest
+            node-version: 15.x
+          # exclude windows node 16 due to another node-gyp bug
+          - os: windows-latest
+            node-version: 16.x
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -9,6 +9,7 @@ jobs:
   build_pub_binaries:
     name: Publish binaries for supported environments for release
     if: "contains(github.event.head_commit.message, 'chore(release): publish')"
+    timeout-minutes: 30
     runs-on: ${{matrix.os}}
     strategy:
       matrix:

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
   "$schema": "http://json.schemastore.org/prettierrc",
   "printWidth": 120,
   "trailingComma": "es5",
-  "proseWrap": "always"
+  "proseWrap": "always",
+  "endOfLine": "auto"
 }

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -13,7 +13,7 @@ To create a stable release follow the following steps
    newly created commit
 9. Push the release branch including the newly created tags `git push origin release --tags`
 10. Open a pull request for the release, once approvals have been sought, merge the pull request using squash,
-    preserving the commit message as `chore(release): publish [skip ci]`
+    preserving the commit message as `chore(release): publish`
 11. Observe the triggering of the `/.github/workflows/push-release.yaml`
 
 The resulting release will publish the new package to NPM and the resulting binaries to github packages.
@@ -27,7 +27,4 @@ The releases have the following version syntax
 
 **Note** Unstable releases include the un-compiled rust required to build the project and hence require rust to install.
 
-**Note** The `/.github/workflows/push-master.yaml` will skip if the commit message includes `[skip ci]`
-
-**Note** To skip the automatic release of a new unstable version append `[skip ci]` to the end of the commit message
-that is merged into master.
+**Note** The `/.github/workflows/push-master.yaml` will skip if the commit message includes `chore(release): publish`

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "publish:binary": "./scripts/publish_binary.sh",
     "publish:ts": "./scripts/publish_ts.sh",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
-    "version:release": "yarn version --minor --message \"chore(release): publish [skip ci]\"",
+    "version:release": "yarn version --minor --message \"chore(release): publish\"",
     "docs": "typedoc --out docs/api src"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Now that all GH actions appear to respond to the [skip ci] convention in GH actions we cannot use it the way it was being used in the release proces.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

See above

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
