### PR TITLE
test: improve createProof test coverage

### DIFF
--- a/__tests__/bbsSignature/createProof.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/createProof.bbsSignature.spec.ts
@@ -119,6 +119,103 @@ describe("bbsSignature", () => {
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(415); //TODO evaluate this length properly add a reason for this and some constants?
     });
+
+    it("should fail to create proof when attempting to create one with an unsigned extra message", async () => {
+      const messages = [
+        stringToBytes("J42AxhciOVkE9w=="),
+        stringToBytes("PNMnARWIHP+s2g=="),
+        stringToBytes("ti9WYhhEej85jw=="),
+        stringToBytes("badmessagex01a=="),
+      ];
+
+      const bbsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA=="
+      );
+      const signature = base64Decode(
+        "qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w=="
+      );
+
+      const request: BbsCreateProofRequest = {
+        signature,
+        publicKey: bbsPublicKey,
+        messages,
+        nonce: randomBytes(10),
+        revealed: [0, 1, 2, 3],
+      };
+
+      await expect(createProof(request)).rejects.toThrowError("Failed to create proof");
+    });
+
+    it("should fail to create proof when attempting to create one with a modified message", async () => {
+      const messages = [
+        stringToBytes("badmessagex01a=="),
+        stringToBytes("PNMnARWIHP+s2g=="),
+        stringToBytes("ti9WYhhEej85jw=="),
+      ];
+
+      const bbsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA=="
+      );
+      const signature = base64Decode(
+        "qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w=="
+      );
+
+      const request: BbsCreateProofRequest = {
+        signature,
+        publicKey: bbsPublicKey,
+        messages,
+        nonce: randomBytes(10),
+        revealed: [0],
+      };
+
+      await expect(createProof(request)).rejects.toThrowError("Failed to create proof");
+    });
+
+    it("should fail to create proof when attempting to create one with missing messages", async () => {
+      const messages = [stringToBytes("badmessagex01a=="), stringToBytes("PNMnARWIHP+s2g==")];
+
+      const bbsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA=="
+      );
+      const signature = base64Decode(
+        "qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w=="
+      );
+
+      const request: BbsCreateProofRequest = {
+        signature,
+        publicKey: bbsPublicKey,
+        messages,
+        nonce: randomBytes(10),
+        revealed: [0],
+      };
+
+      await expect(createProof(request)).rejects.toThrowError("Failed to create proof");
+    });
+
+    it("should fail to create proof when attempting to create one with messages supplied in wrong order", async () => {
+      const messages = [
+        stringToBytes("ti9WYhhEej85jw=="),
+        stringToBytes("PNMnARWIHP+s2g=="),
+        stringToBytes("J42AxhciOVkE9w=="),
+      ];
+
+      const bbsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA=="
+      );
+      const signature = base64Decode(
+        "qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w=="
+      );
+
+      const request: BbsCreateProofRequest = {
+        signature,
+        publicKey: bbsPublicKey,
+        messages,
+        nonce: randomBytes(10),
+        revealed: [0],
+      };
+
+      await expect(createProof(request)).rejects.toThrowError("Failed to create proof");
+    });
   });
 
   describe("blsCreateProof", () => {
@@ -223,6 +320,103 @@ describe("bbsSignature", () => {
       const proof = await blsCreateProof(request);
       expect(proof).toBeInstanceOf(Uint8Array);
       expect(proof.length).toEqual(415); //TODO evaluate this length properly add a reason for this and some constants?
+    });
+
+    it("should fail to create proof when attempting to create one with an unsigned extra message", async () => {
+      const messages = [
+        stringToBytes("uiSKIfNoO2rMrA=="),
+        stringToBytes("lMoHHrFx0LxwAw=="),
+        stringToBytes("wdwqLVm9chMMnA=="),
+        stringToBytes("badmessagex01a=="),
+      ];
+
+      const blsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
+      );
+      const signature = base64Decode(
+        "jU9tKKvDDqoSUTMPDGfw/1GlnOnRD56wEM2iftL7NPBlT3JxP2YY5SnR32nra0bmR//r8JH7fvgYuqpXHJB+vsYj7xoeyQtvoPZArti0YiYML2utQmsV4zN1W0sWH7+myPL/7H/m6PgxL/CjYzAaRg=="
+      );
+
+      const request: BbsCreateProofRequest = {
+        signature,
+        publicKey: blsPublicKey,
+        messages,
+        nonce: randomBytes(10),
+        revealed: [0, 1, 2, 3],
+      };
+
+      await expect(createProof(request)).rejects.toThrowError("Failed to create proof");
+    });
+
+    it("should fail to create proof when attempting to create one with a modified message", async () => {
+      const messages = [
+        stringToBytes("badmessagex01a=="),
+        stringToBytes("lMoHHrFx0LxwAw=="),
+        stringToBytes("wdwqLVm9chMMnA=="),
+      ];
+
+      const blsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
+      );
+      const signature = base64Decode(
+        "jU9tKKvDDqoSUTMPDGfw/1GlnOnRD56wEM2iftL7NPBlT3JxP2YY5SnR32nra0bmR//r8JH7fvgYuqpXHJB+vsYj7xoeyQtvoPZArti0YiYML2utQmsV4zN1W0sWH7+myPL/7H/m6PgxL/CjYzAaRg=="
+      );
+
+      const request: BbsCreateProofRequest = {
+        signature,
+        publicKey: blsPublicKey,
+        messages,
+        nonce: randomBytes(10),
+        revealed: [0],
+      };
+
+      await expect(createProof(request)).rejects.toThrowError("Failed to create proof");
+    });
+
+    it("should fail to create proof when attempting to create one with missing messages", async () => {
+      const messages = [stringToBytes("lMoHHrFx0LxwAw=="), stringToBytes("wdwqLVm9chMMnA==")];
+
+      const blsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
+      );
+      const signature = base64Decode(
+        "jU9tKKvDDqoSUTMPDGfw/1GlnOnRD56wEM2iftL7NPBlT3JxP2YY5SnR32nra0bmR//r8JH7fvgYuqpXHJB+vsYj7xoeyQtvoPZArti0YiYML2utQmsV4zN1W0sWH7+myPL/7H/m6PgxL/CjYzAaRg=="
+      );
+
+      const request: BbsCreateProofRequest = {
+        signature,
+        publicKey: blsPublicKey,
+        messages,
+        nonce: randomBytes(10),
+        revealed: [0],
+      };
+
+      await expect(createProof(request)).rejects.toThrowError("Failed to create proof");
+    });
+
+    it("should fail to create proof when attempting to create one with a modified message", async () => {
+      const messages = [
+        stringToBytes("wdwqLVm9chMMnA=="),
+        stringToBytes("lMoHHrFx0LxwAw=="),
+        stringToBytes("uiSKIfNoO2rMrA=="),
+      ];
+
+      const blsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
+      );
+      const signature = base64Decode(
+        "jU9tKKvDDqoSUTMPDGfw/1GlnOnRD56wEM2iftL7NPBlT3JxP2YY5SnR32nra0bmR//r8JH7fvgYuqpXHJB+vsYj7xoeyQtvoPZArti0YiYML2utQmsV4zN1W0sWH7+myPL/7H/m6PgxL/CjYzAaRg=="
+      );
+
+      const request: BbsCreateProofRequest = {
+        signature,
+        publicKey: blsPublicKey,
+        messages,
+        nonce: randomBytes(10),
+        revealed: [0],
+      };
+
+      await expect(createProof(request)).rejects.toThrowError("Failed to create proof");
     });
   });
 });

--- a/__tests__/bbsSignature/verifyProof.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/verifyProof.bbsSignature.spec.ts
@@ -228,6 +228,31 @@ describe("bbsSignature", () => {
       expect(result.verified).toBeTruthy();
     });
 
+    it("should verify proof with multiple messages revealed from multi-message signature", async () => {
+      const messages = [
+        stringToBytes("uiSKIfNoO2rMrA=="),
+        stringToBytes("lMoHHrFx0LxwAw=="),
+        stringToBytes("wdwqLVm9chMMnA=="),
+      ];
+      const blsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
+      );
+      const proof = base64Decode(
+        "AAMFkCuKmSKVB4QeCczJx4gBEtGoYY2ChhcNMYTbVa1L/vpcWmFYwUQHNN+n9TetMJygkJETUL30Zv+iYqplSMkdTBDe36TZKlCi+2+MaIhh66HsJT7lWcvpkxI3uC8SyDEutqVSIaVdsb1czpiQbxbjfo+Cg5nPw3qKpeSb7kGY3dMRRMd/Ug0YnGEN9eUqsWt/AAAAdKeTj+pJJiAVX9FuWIv7c4GVYEfzwyD7WXGBIWdrKIZdRLOIn+NGUmIdutzRr9ISiQAAAAIR2WRLfTY/mnmo4oz9iOgQwpoELlkXpU5Gx0sLMMBbxgqjg9aktKyVy6HXuWLafe1YyoV7acXWRbvfwPMoI/dwuDBAJQ30CHN+GD/ZkGvEq5VfogWE1gttKmwzwDatvaYuc16aC4BkdJ6qu+H9Z4+rAAAAA12Q0JuR4V606bCaqYLw+JzSkoyGGIviZnBezqR4pINTUPXBQQQ57cm8l5ldBM0uM6220n40hrc6kVKgJpUcIC8N68lTkdo/RGTF4lYdwYz7L7lZwmaSSLuGi0J+n7mbUA=="
+      );
+
+      const revealedMessages = [messages[0], messages[2]];
+
+      const request: BbsVerifyProofRequest = {
+        proof,
+        publicKey: blsPublicKey,
+        messages: revealedMessages,
+        nonce: base64Decode("csBYAufrvE1zkg=="),
+      };
+      const result = await blsVerifyProof(request);
+      expect(result.verified).toBeTruthy();
+    });
+
     it("should verify proof with one message revealed from multi-message signature", async () => {
       const messages = [
         stringToBytes("8NhsJO/MKxO74A=="),


### PR DESCRIPTION
## Description

Improves test coverage over the createProof API, this PR also improves the module loading logic when in NodeJS environments, so the CJS module can be consumed in non-NodeJS environments.

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

See above

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)