### PR TITLE
Strict check for given messages count and originally revealed

### DIFF
--- a/__tests__/bbsSignature/verifyProof.bbsSignature.spec.ts
+++ b/__tests__/bbsSignature/verifyProof.bbsSignature.spec.ts
@@ -301,6 +301,31 @@ describe("bbsSignature", () => {
       expect(result.verified).toBeTruthy();
     });
 
+    it("should not verify with more given messages than revealed", async () => {
+      const messages = [
+        stringToBytes("8NhsJO/MKxO74A=="),
+        stringToBytes("0noLBcl29ASJ2w=="),
+        stringToBytes("eMPpY348vqGDNA=="),
+      ];
+      const blsPublicKey = base64Decode(
+        "qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb"
+      );
+      const proof = base64Decode(
+        "AAMBjl1W6j/1y/M3V4OIluw3BSTvgKCYRh+2SSeNNfDSZzKqNJAlQMGfHvBzpFQN55MZscHwEmMM6yWK2dqKGVhecvkwUvOIogpMFTbf3ikMor375ddSB3MAuHvgmlZKdLz7iwbxoCrf4+zfDvYeeLF6QR1uMdUa7v50ix2ZeSllsmOk5NxrEVMZXJ/+SDfASgTZAAAAdJeaUx4qwv5W72EKCDSBIYfxwlj28IGx0TnDm0E1y10n3hE0SIKYzgqqE81SPV9jfwAAAAIdssV4x73UeqxXmgQJSMO4XKDiiyxprlrpyz+1tINi7QbUABSCe4T1pdYOS0miYLDwzy2/zS2uuJ12yfqj6S1hl0U/uNbr03t8xypruPQhYreQGanMpFCnZquOJ9CYTGSPwMl1Hlva5hW0Jcrwugn1AAAABDLHtpcxsutFpn2EiPTYZMEeNnVr2x5AggpCAuLfd0+JBKEEwHKANSeajnWKBZ0YkZ/MpXkpU3ThRYWijpb6EsE4QJzkzSzKt5ZQCXsRkFLg/gWZIAUzKEjk3G2ELrFHlR9AedW1eANiHF/4ZuQPAtlRYg+mxeiEp87/xoLdq+OA"
+      );
+
+      const revealedMessages = messages.slice(0, 2);
+
+      const request: BbsVerifyProofRequest = {
+        proof,
+        publicKey: blsPublicKey,
+        messages: revealedMessages,
+        nonce: stringToBytes("I03DvFXcpVdOPuOiyXgcBf4voAA="),
+      };
+      const result = await blsVerifyProof(request);
+      expect(result.verified).toBeFalsy();
+    });
+
     it("should not verify with malformed proof", async () => {
       const messages = [
         stringToBytes("Message1"),

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -860,6 +860,11 @@ fn extract_verify_proof_context(cx: &mut FunctionContext, is_bls: bool) -> Resul
     // let revealed_indices = obj_field_to_vec!(cx, js_obj, "revealed");
     let message_bytes = obj_field_to_vec!(cx, js_obj, "messages");
 
+    if message_bytes.len() != revealed.len() {
+        panic!("Given messages count ({}) is different from revealed messages count ({}) for this proof",
+            message_bytes.len(), revealed.len());
+    }
+
     let mut messages = Vec::new();
     for i in 0..message_bytes.len() {
         let message = obj_field_to_field_elem!(cx, message_bytes[i]);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

<!--- Describe your changes in detail -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context
The main point of this PR is to restrict providing more messages to the `blsVerifyProof` than it was revealed originally. For now it is possible to provide all revealed + signed messages in the right order and then add to the messages array some additional, not signed, not revealed messages and receive a successful response `result.verified === true`. More details in the [issue](https://github.com/mattrglobal/node-bbs-signatures/issues/174)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
