### PR TITLE
chore: non-zero exit code if there are releasing errors

### DIFF
--- a/scripts/publish_binary.sh
+++ b/scripts/publish_binary.sh
@@ -27,8 +27,9 @@ copyfiles index.node native
 # Package the binary
 yarn package
 
-# Publish the binary to github packages
-node-pre-gyp-github publish --release
+# Publish the binary to github packages using strict
+# so that this script can catch failures (network, auth, etc.)
+node --unhandled-rejections=strict ./node_modules/.bin/node-pre-gyp-github publish --release
 
 # Reset changes to the package.json
 git checkout -- package.json

--- a/scripts/publish_binary.sh
+++ b/scripts/publish_binary.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# fail if any command in script fails
+set -e 
+
 # This script handling the publishing of the current 
 # commits generated binaries as an unstable package
 

--- a/scripts/publish_ts.sh
+++ b/scripts/publish_ts.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# fail if any command in script fails
+set -e 
+
 # This script handling the publishing of the current 
 # commits typescript based library as an unstable package
 

--- a/scripts/publish_unstable_ts.sh
+++ b/scripts/publish_unstable_ts.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# fail if any command in script fails
+set -e
+
 # This script handling the publishing of the current 
 # commits typescript based library as an unstable package
 


### PR DESCRIPTION
Changes how `node-pre-gyp-github` is called so that if errors occur, they will bubble up. Also adds `set -e` which tells the Bash scripts to exit if any command fails.

## Description

By default Bash scripts continue to run even if one command fails. Releasing is made up of many steps but is usually considered an atomic operation. By adding `set -e` the GitHub action will tell us if there was a problem releasing, which we want to know.

<!--- Describe your changes in detail -->

- [x] ~Tests for the changes have been added (for bug fixes / features)~
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

[This action](https://github.com/mattrglobal/node-bbs-signatures/runs/7274880392?check_suite_focus=true#step:8:17) was marked successful, but it caused problems for people who were wondering why master did not release.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
