### PR TITLE
chore: pin github actions versions

### DIFF
--- a/.github/workflows/github_backup.yaml
+++ b/.github/workflows/github_backup.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # pin @v1.6.1
         with:
           aws-region: ap-southeast-2
           role-to-assume: arn:aws:iam::817632051851:role/oidc-github-actions-mattrglobal-global
@@ -22,7 +22,7 @@ jobs:
           role-session-name: GithubActions
 
       - name: Backing up this repo to AWS S3
-        uses: peter-evans/s3-backup@v1
+        uses: peter-evans/s3-backup@4f39c7dab63c7666d6ba6722d7966e7d0655583c # pin @v1.1.0
         env:
           AWS_REGION: ${{ env.AWS_REGION }}
           ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -31,6 +31,6 @@ jobs:
       - run: git config user.email "npmjs_ci_mattr_public@mattr.global"
       - run: yarn publish:unstable:ts
       - name: Report Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # pin@1.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
As part of the preparation for the Trail of Bits audit we are pinning all non GitHub owned actions.

## Description

Pinning:
- configure-aws-credentials to v1.6.1 with this [commit](https://github.com/aws-actions/configure-aws-credentials/commit/05b148adc31e091bafbaf404f745055d4d3bc9d2)
- s3-backup to v1.1.0 with this [commit](https://github.com/peter-evans/s3-backup/commit/4f39c7dab63c7666d6ba6722d7966e7d0655583c)
- codecov to v1.5.2 with this [commit](https://github.com/codecov/codecov-action/commit/29386c70ef20e286228c72b668a06fd0e8399192)

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

[DXM-854](https://mattrglobal.atlassian.net/jira/software/c/projects/DXM/boards/49?modal=detail&selectedIssue=DXM-854)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)