### PR TITLE
(WIP)chore: add node 18 support

### DIFF
--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -7,8 +7,9 @@ jobs:
     name: Build test
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/push-binary-dispatch.yml
+++ b/.github/workflows/push-binary-dispatch.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [macos-latest]
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "neon"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c562b89fa7f9707f02056abe25a37ec290ca4a4f1596edbd7aa1aa7b87af1d"
+checksum = "5e85820b585bf3360bf158ac87a75764c48e361c91bbeb69873e6613cc78c023"
 dependencies = [
  "cslice",
  "neon-build",
@@ -389,18 +389,18 @@ dependencies = [
 
 [[package]]
 name = "neon-build"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c55f6d310757b9fe6cd96a376609548a252da31828f935a7f59106533a89e9"
+checksum = "ad9febc63f515156d4311a0c43899d3ace46352ecdd591c21b98ca3974f2a0d0"
 dependencies = [
  "neon-sys",
 ]
 
 [[package]]
 name = "neon-runtime"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be313e6cf11f469653ee1b137b9203f5d604f2b496d423e96c5e251b51eead03"
+checksum = "02662cd2e62b131937bdef85d0918b05bc3c204daf4c64af62845403eccb60f3"
 dependencies = [
  "cfg-if",
  "neon-sys",
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "neon-sys"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7311a8aca212437bb95c4e5eb94b19a4c360440db118021cd90c3d63387613"
+checksum = "dc2fd32e08c4681b0004b3dce16a9f647a8023af7b8dde3bb3ac423034803830"
 dependencies = [
  "cc",
  "regex",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -203,12 +203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cslice"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
-
-[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,11 +370,10 @@ dependencies = [
 
 [[package]]
 name = "neon"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e85820b585bf3360bf158ac87a75764c48e361c91bbeb69873e6613cc78c023"
+checksum = "28e15415261d880aed48122e917a45e87bb82cf0260bb6db48bbab44b7464373"
 dependencies = [
- "cslice",
  "neon-build",
  "neon-runtime",
  "semver",
@@ -389,18 +382,18 @@ dependencies = [
 
 [[package]]
 name = "neon-build"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9febc63f515156d4311a0c43899d3ace46352ecdd591c21b98ca3974f2a0d0"
+checksum = "8bac98a702e71804af3dacfde41edde4a16076a7bbe889ae61e56e18c5b1c811"
 dependencies = [
  "neon-sys",
 ]
 
 [[package]]
 name = "neon-runtime"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02662cd2e62b131937bdef85d0918b05bc3c204daf4c64af62845403eccb60f3"
+checksum = "4676720fa8bb32c64c3d9f49c47a47289239ec46b4bdb66d0913cc512cb0daca"
 dependencies = [
  "cfg-if",
  "neon-sys",
@@ -409,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "neon-sys"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fd32e08c4681b0004b3dce16a9f647a8023af7b8dde3bb3ac423034803830"
+checksum = "a5ebc923308ac557184455b4aaa749470554cbac70eb4daa8b18cdc16bef7df6"
 dependencies = [
  "cc",
  "regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,7 +10,7 @@ name = "node_bbs_signatures"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-neon-build = "0.9.1"
+neon-build = "0.10.1"
 
 [dependencies]
 arrayref = "0.3"
@@ -18,7 +18,7 @@ bbs = "0.4.1"
 bls_sigs_ref = "0.3"
 ff-zeroize = "0.6"
 hkdf = "0.8"
-neon = "0.9.1"
+neon = "0.10.1"
 pairing-plus = "0.19"
 rand = "0.7"
 sha2 = "0.8"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,7 +10,7 @@ name = "node_bbs_signatures"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-neon-build = "0.8"
+neon-build = "0.9.1"
 
 [dependencies]
 arrayref = "0.3"
@@ -18,7 +18,7 @@ bbs = "0.4.1"
 bls_sigs_ref = "0.3"
 ff-zeroize = "0.6"
 hkdf = "0.8"
-neon = "0.8"
+neon = "0.9.1"
 pairing-plus = "0.19"
 rand = "0.7"
 sha2 = "0.8"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "typescript": "4.3.3"
   },
   "dependencies": {
-    "@mapbox/node-pre-gyp": "1.0.9",
+    "@mapbox/node-pre-gyp": "1.0.11",
     "neon-cli": "0.10.1"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,10 +706,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@mapbox/node-pre-gyp@1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz#09a8781a3a036151cdebbe8719d6f8b25d4058bc"
-  integrity sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==
+"@mapbox/node-pre-gyp@1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
+  integrity sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==
   dependencies:
     detect-libc "^2.0.0"
     https-proxy-agent "^5.0.0"


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

<!--- Describe your changes in detail -->

* had tried bump neon and neon-build in Cargo.toml to 0.9.1 successfully builded on 18.x, ubuntu-latest ✅ [here](https://github.com/mattrglobal/node-bbs-signatures/actions/runs/5863674298/job/15897549238)
18.x, macos-latest failed when try to Compiling crossbeam-channel v0.5.5 [here](https://github.com/mattrglobal/node-bbs-signatures/actions/runs/5863674298/job/15897549156)
locally with M2 running yarn install && yarn build
neon 0.9.1 failed around Compiling bbs v0.4.1
neon 0.10.1 failed around Compiling node-bbs-signatures v0.1.0

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [ ] Squash
- [ ] Rebase (REVIEW COMMITS)
