### PR TITLE
feat: add node 18 support

### DIFF
--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -7,6 +7,7 @@ jobs:
     name: Build test
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/push-binary-dispatch.yml
+++ b/.github/workflows/push-binary-dispatch.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         os: [macos-latest]
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-binary-dispatch.yml
+++ b/.github/workflows/push-binary-dispatch.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [macos-latest]
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-binary-dispatch.yml
+++ b/.github/workflows/push-binary-dispatch.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [macos-latest]
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v2

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -203,12 +203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cslice"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
-
-[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,11 +370,10 @@ dependencies = [
 
 [[package]]
 name = "neon"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c562b89fa7f9707f02056abe25a37ec290ca4a4f1596edbd7aa1aa7b87af1d"
+checksum = "28e15415261d880aed48122e917a45e87bb82cf0260bb6db48bbab44b7464373"
 dependencies = [
- "cslice",
  "neon-build",
  "neon-runtime",
  "semver",
@@ -389,18 +382,18 @@ dependencies = [
 
 [[package]]
 name = "neon-build"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c55f6d310757b9fe6cd96a376609548a252da31828f935a7f59106533a89e9"
+checksum = "8bac98a702e71804af3dacfde41edde4a16076a7bbe889ae61e56e18c5b1c811"
 dependencies = [
  "neon-sys",
 ]
 
 [[package]]
 name = "neon-runtime"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be313e6cf11f469653ee1b137b9203f5d604f2b496d423e96c5e251b51eead03"
+checksum = "4676720fa8bb32c64c3d9f49c47a47289239ec46b4bdb66d0913cc512cb0daca"
 dependencies = [
  "cfg-if",
  "neon-sys",
@@ -409,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "neon-sys"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7311a8aca212437bb95c4e5eb94b19a4c360440db118021cd90c3d63387613"
+checksum = "a5ebc923308ac557184455b4aaa749470554cbac70eb4daa8b18cdc16bef7df6"
 dependencies = [
  "cc",
  "regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,7 +10,7 @@ name = "node_bbs_signatures"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-neon-build = "0.8"
+neon-build = "0.10.1"
 
 [dependencies]
 arrayref = "0.3"
@@ -18,7 +18,7 @@ bbs = "0.4.1"
 bls_sigs_ref = "0.3"
 ff-zeroize = "0.6"
 hkdf = "0.8"
-neon = "0.8"
+neon = "0.10.1"
 pairing-plus = "0.19"
 rand = "0.7"
 sha2 = "0.8"

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -25,7 +25,6 @@ use neon::result::Throw;
 use pairing_plus::{bls12_381::{Fr, G1, G2, Bls12}, serdes::SerDes, hash_to_field::BaseFromRO, CurveProjective};
 use rand::{thread_rng, RngCore};
 use std::collections::{BTreeMap, BTreeSet};
-use std::ops::Deref;
 
 // This shows how the generators are created with nothing up my sleeve values
 // const PREHASH: &'static [u8] = b"To be, or not to be- that is the question:

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -25,6 +25,7 @@ use neon::result::Throw;
 use pairing_plus::{bls12_381::{Fr, G1, G2, Bls12}, serdes::SerDes, hash_to_field::BaseFromRO, CurveProjective};
 use rand::{thread_rng, RngCore};
 use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Deref;
 
 // This shows how the generators are created with nothing up my sleeve values
 // const PREHASH: &'static [u8] = b"To be, or not to be- that is the question:

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -289,7 +289,7 @@ fn bbs_sign(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
     ));
 
     let pk_bytes = obj_field_to_slice!(&mut cx, js_obj, "publicKey");
-    let pk = PublicKey::from_bytes_compressed_form(pk_bytes.as_slice()).unwrap();
+    let pk = PublicKey::from_bytes_compressed_form(pk_bytes).unwrap();
 
     if pk.validate().is_err() {
         panic!("Invalid key");
@@ -335,7 +335,7 @@ fn bbs_verify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     ));
 
     let pk_bytes = obj_field_to_slice!(&mut cx, js_obj, "publicKey");
-    let pk = PublicKey::from_bytes_compressed_form(pk_bytes.as_slice()).unwrap();
+    let pk = PublicKey::from_bytes_compressed_form(pk_bytes).unwrap();
 
     if pk.validate().is_err() {
         panic!("Invalid key");
@@ -420,7 +420,7 @@ fn extract_blinding_context(cx: &mut FunctionContext) -> Result<BlindingContext,
     let js_obj = cx.argument::<JsObject>(0)?;
 
     let pk_bytes = obj_field_to_slice!(cx, js_obj, "publicKey");
-    let public_key = PublicKey::from_bytes_compressed_form(pk_bytes.as_slice()).unwrap();
+    let public_key = PublicKey::from_bytes_compressed_form(pk_bytes).unwrap();
 
     if public_key.validate().is_err() {
         panic!("Invalid key");
@@ -491,7 +491,7 @@ struct BlindingContext {
 fn bbs_verify_blind_signature_proof(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let js_obj = cx.argument::<JsObject>(0)?;
     let pk_bytes = obj_field_to_slice!(&mut cx, js_obj, "publicKey");
-    let public_key = PublicKey::from_bytes_compressed_form(pk_bytes.as_slice()).unwrap();
+    let public_key = PublicKey::from_bytes_compressed_form(pk_bytes).unwrap();
     if public_key.validate().is_err() {
         panic!("Invalid key");
     }
@@ -591,7 +591,7 @@ fn extract_blind_signature_context(cx: &mut FunctionContext) -> Result<BlindSign
     ));
 
     let pk_bytes = obj_field_to_slice!(cx, js_obj, "publicKey");
-    let public_key = PublicKey::from_bytes_compressed_form(pk_bytes.as_slice()).unwrap();
+    let public_key = PublicKey::from_bytes_compressed_form(pk_bytes).unwrap();
     if public_key.validate().is_err() {
         panic!("Invalid key");
     }
@@ -723,7 +723,7 @@ fn extract_create_proof_context(cx: &mut FunctionContext) -> Result<(Vec<u8>, Cr
         SIGNATURE_COMPRESSED_SIZE
     ));
     let pk_bytes = obj_field_to_slice!(cx, js_obj, "publicKey");
-    let public_key = PublicKey::from_bytes_compressed_form(pk_bytes.as_slice()).unwrap();
+    let public_key = PublicKey::from_bytes_compressed_form(pk_bytes).unwrap();
     if public_key.validate().is_err() {
         panic!("Invalid key");
     }
@@ -883,7 +883,7 @@ fn extract_verify_proof_context(cx: &mut FunctionContext, is_bls: bool) -> Resul
         dpk.to_public_key(message_count).unwrap()
     } else {
         let pk_bytes = obj_field_to_slice!(cx, js_obj, "publicKey");
-        PublicKey::from_bytes_compressed_form(pk_bytes.as_slice()).unwrap()
+        PublicKey::from_bytes_compressed_form(pk_bytes).unwrap()
     };
     if public_key.validate().is_err() {
         panic!("Invalid key");

--- a/native/src/macros.rs
+++ b/native/src/macros.rs
@@ -77,16 +77,6 @@ macro_rules! obj_field_to_vec {
     }};
 }
 
-/*macro_rules! cast_to_slice {
-    ($cx:expr, $obj:expr) => {{
-        //let arg = $obj.downcast::<JsArrayBuffer>().or_throw($cx)?;
-        //$cx.borrow(&arg, |d: JsArrayBuffer| d.as_slice::<u8>()).to_vec()
-        //let guard = $cx.lock()
-        //let data = $expr.borrow(
-        $obj.as_slice(&$cx)
-    }};
-}*/
-
 macro_rules! cast_to_number {
     ($cx:expr, $obj:expr) => {
         $obj.downcast::<JsNumber>()

--- a/native/src/macros.rs
+++ b/native/src/macros.rs
@@ -103,14 +103,13 @@ macro_rules! handle_err {
 
 macro_rules! obj_field_to_field_elem {
     ($cx:expr, $d:expr) => {{
-        //let m = $d.as_slice(&$cx);
         let m = $d.downcast::<JsObject>()
             .or_throw($cx)?
             .get::<JsArrayBuffer, _, _>($cx, $d)?
             .borrow(&$cx.lock())
             .deref()
             .as_slice()
-            .to_vec();//cast_to_slice!($cx, $d);
+            .to_vec();
         SignatureMessage::hash(m)
     }};
 }
@@ -119,8 +118,6 @@ macro_rules! get_message_count {
     ($cx:expr, $obj:expr, $field:expr) => {{
         let message_count: f64 = $obj
             .get::<JsNumber, _, _>($cx, $field)?
-            //.downcast::<JsNumber>()
-            //.unwrap_or($cx.number(-1))
             .value();
 
         if message_count < 0f64 {

--- a/native/src/macros.rs
+++ b/native/src/macros.rs
@@ -42,14 +42,24 @@ macro_rules! arg_to_fixed_array {
 macro_rules! obj_field_to_slice {
     ($cx:expr, $obj:expr, $field:expr) => {{
         let a = $obj.get::<JsArrayBuffer, _, _>($cx, $field)?.deref();
-        a.borrow(&$cx.lock()).deref().as_slice()
+        a.borrow(&$cx.lock()).deref().as_slice().to_vec()
+    }};
+}
+
+macro_rules! obj_field_to_slice {
+    ($cx:expr, $obj:expr, $field:expr) => {{
+        let maybe_buffer = $obj.get::<JsArrayBuffer, _, _>($cx, $field)?;
+        let a = maybe_buffer.deref();
+        let b = a.borrow(&$cx.lock()).deref().as_slice();
+        b.to_vec()
     }};
 }
 
 macro_rules! obj_field_to_fixed_array {
     ($cx:expr, $obj:expr, $field:expr, $start:expr, $end:expr) => {{
-        let a: &JsArrayBuffer = $obj.get::<JsArrayBuffer, _, _>($cx, $field)?.deref();
-        let b =  a.borrow(&$cx.lock()).deref().as_slice();
+        let maybe_buffer = $obj.get::<JsArrayBuffer, _, _>($cx, $field)?;
+        let a: &JsArrayBuffer = maybe_buffer.deref();
+        let b = a.borrow(&$cx.lock()).deref().as_slice();
         if b.len() != $end {
             panic!("Invalid length");
         }
@@ -99,7 +109,8 @@ macro_rules! obj_field_to_field_elem {
             .get::<JsArrayBuffer, _, _>($cx, $d)?
             .borrow(&$cx.lock())
             .deref()
-            .as_slice();//cast_to_slice!($cx, $d);
+            .as_slice()
+            .to_vec();//cast_to_slice!($cx, $d);
         SignatureMessage::hash(m)
     }};
 }

--- a/native/src/macros.rs
+++ b/native/src/macros.rs
@@ -95,13 +95,14 @@ macro_rules! handle_err {
 
 macro_rules! obj_field_to_field_elem {
     ($cx:expr, $d:expr) => {{
-        let m = $d
+        let handle  = $d
             .downcast::<JsArrayBuffer>()
-            .or_throw($cx)?
-            .borrow(&$cx.lock())
-            .as_slice()
-            .to_vec();
-        SignatureMessage::hash(m)
+            .or_throw($cx)?;
+
+        $cx.borrow(&handle, |data| {
+            let slice = data.as_slice();
+            SignatureMessage::hash(slice)
+        })
     }};
 }
 

--- a/native/src/macros.rs
+++ b/native/src/macros.rs
@@ -41,29 +41,21 @@ macro_rules! arg_to_fixed_array {
 
 macro_rules! obj_field_to_slice {
     ($cx:expr, $obj:expr, $field:expr) => {{
-        let a = $obj.get::<JsArrayBuffer, _, _>($cx, $field)?.deref();
-        a.borrow(&$cx.lock()).deref().as_slice().to_vec()
-    }};
-}
-
-macro_rules! obj_field_to_slice {
-    ($cx:expr, $obj:expr, $field:expr) => {{
-        let maybe_buffer = $obj.get::<JsArrayBuffer, _, _>($cx, $field)?;
-        let a = maybe_buffer.deref();
-        let b = a.borrow(&$cx.lock()).deref().as_slice();
-        b.to_vec()
+        $obj.get::<JsArrayBuffer, _, _>($cx, $field)?
+            .deref()
+            .borrow(&$cx.lock())
+            .as_slice().to_vec()
     }};
 }
 
 macro_rules! obj_field_to_fixed_array {
     ($cx:expr, $obj:expr, $field:expr, $start:expr, $end:expr) => {{
-        let maybe_buffer = $obj.get::<JsArrayBuffer, _, _>($cx, $field)?;
-        let a: &JsArrayBuffer = maybe_buffer.deref();
-        let b = a.borrow(&$cx.lock()).deref().as_slice();
-        if b.len() != $end {
+        let handle  = $obj.get::<JsArrayBuffer, _, _>($cx, $field)?;
+        let array = handle.deref().borrow(&$cx.lock()).as_slice();
+        if array.len() != $end {
             panic!("Invalid length");
         }
-        *array_ref![b, $start, $end]
+        *array_ref![array, $start, $end]
     }};
 }
 

--- a/native/src/macros.rs
+++ b/native/src/macros.rs
@@ -95,9 +95,7 @@ macro_rules! handle_err {
 
 macro_rules! obj_field_to_field_elem {
     ($cx:expr, $d:expr) => {{
-        let handle  = $d
-            .downcast::<JsArrayBuffer>()
-            .or_throw($cx)?;
+        let handle = $d.downcast::<JsArrayBuffer>().or_throw($cx)?;
 
         $cx.borrow(&handle, |data| {
             let slice = data.as_slice();

--- a/native/src/macros.rs
+++ b/native/src/macros.rs
@@ -42,16 +42,16 @@ macro_rules! arg_to_fixed_array {
 macro_rules! obj_field_to_slice {
     ($cx:expr, $obj:expr, $field:expr) => {{
         $obj.get::<JsArrayBuffer, _, _>($cx, $field)?
-            .deref()
             .borrow(&$cx.lock())
-            .as_slice().to_vec()
+            .as_slice()
+            .to_vec()
     }};
 }
 
 macro_rules! obj_field_to_fixed_array {
     ($cx:expr, $obj:expr, $field:expr, $start:expr, $end:expr) => {{
-        let handle  = $obj.get::<JsArrayBuffer, _, _>($cx, $field)?;
-        let array = handle.deref().borrow(&$cx.lock()).as_slice();
+        let handle = $obj.get::<JsArrayBuffer, _, _>($cx, $field)?;
+        let array = handle.borrow(&$cx.lock()).as_slice();
         if array.len() != $end {
             panic!("Invalid length");
         }
@@ -63,7 +63,7 @@ macro_rules! obj_field_to_opt_slice {
     ($cx:expr, $obj:expr, $field:expr) => {{
         match $obj.get::<JsArrayBuffer, _, _>($cx, $field) {
             Err(_) => None,
-            Ok(arg) => Some(arg.borrow(&$cx.lock()).deref().as_slice().to_vec())
+            Ok(arg) => Some(arg.borrow(&$cx.lock()).as_slice().to_vec()),
         }
     }};
 }
@@ -95,10 +95,10 @@ macro_rules! handle_err {
 
 macro_rules! obj_field_to_field_elem {
     ($cx:expr, $d:expr) => {{
-        let m = $d.downcast::<JsArrayBuffer>()
+        let m = $d
+            .downcast::<JsArrayBuffer>()
             .or_throw($cx)?
             .borrow(&$cx.lock())
-            .deref()
             .as_slice()
             .to_vec();
         SignatureMessage::hash(m)
@@ -107,9 +107,7 @@ macro_rules! obj_field_to_field_elem {
 
 macro_rules! get_message_count {
     ($cx:expr, $obj:expr, $field:expr) => {{
-        let message_count: f64 = $obj
-            .get::<JsNumber, _, _>($cx, $field)?
-            .value();
+        let message_count: f64 = $obj.get::<JsNumber, _, _>($cx, $field)?.value();
 
         if message_count < 0f64 {
             panic!("Message count cannot be negative: {}", message_count);

--- a/native/src/macros.rs
+++ b/native/src/macros.rs
@@ -103,9 +103,8 @@ macro_rules! handle_err {
 
 macro_rules! obj_field_to_field_elem {
     ($cx:expr, $d:expr) => {{
-        let m = $d.downcast::<JsObject>()
+        let m = $d.downcast::<JsArrayBuffer>()
             .or_throw($cx)?
-            .get::<JsArrayBuffer, _, _>($cx, $d)?
             .borrow(&$cx.lock())
             .deref()
             .as_slice()

--- a/native/tests/vectors.rs
+++ b/native/tests/vectors.rs
@@ -18,6 +18,7 @@ extern crate bbs;
 
 use bbs::prelude::*;
 use std::collections::BTreeSet;
+use std::convert::TryFrom;
 
 /// Computed by calling
 ///

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@commitlint/cli": "17.0.2",
     "@commitlint/config-conventional": "17.0.2",
-    "@mathquis/node-pre-gyp-github": "1.0.1",
+    "@mathquis/node-pre-gyp-github": "1.0.2",
     "@stablelib/base64": "1.0.0",
     "@stablelib/benchmark": "1.0.0",
     "@stablelib/random": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "typescript": "4.3.3"
   },
   "dependencies": {
-    "@mapbox/node-pre-gyp": "1.0.9",
+    "@mapbox/node-pre-gyp": "1.0.11",
     "neon-cli": "0.10.1"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,10 +721,10 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@mathquis/node-pre-gyp-github@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@mathquis/node-pre-gyp-github/-/node-pre-gyp-github-1.0.1.tgz#57429d98f8c1169cb6fe138939233c7cb34a6498"
-  integrity sha512-zdUnMiurUPOgV3F1ROcSsVDIshqzdBDEdHg+obVwlV5noswCUeCjg6j966OPO76RrDB0kwFo7yfYLeeHpWeN5w==
+"@mathquis/node-pre-gyp-github@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@mathquis/node-pre-gyp-github/-/node-pre-gyp-github-1.0.2.tgz#de777222705312c2b806645cbbe5bcb1af92c00d"
+  integrity sha512-N2Yb1pTR5hEJjnfDD97UJXLGnG7B+9DMBiHiEXQ4B49P33YJcnvyNnA8xHUvhGu9XaAOw9pMUvweWoFrPVKY8g==
   dependencies:
     "@octokit/rest" "^18.1.1"
     commander "^7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,10 +706,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@mapbox/node-pre-gyp@1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz#09a8781a3a036151cdebbe8719d6f8b25d4058bc"
-  integrity sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==
+"@mapbox/node-pre-gyp@1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
+  integrity sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==
   dependencies:
     detect-libc "^2.0.0"
     https-proxy-agent "^5.0.0"


### PR DESCRIPTION
This library now supports Node 18.

## Description

1. Node 18 added to all GitHub actions.
2. Fail-fast now activated on the _any-pr_ action - it might fail on one version of Node, but build on another. It is helpful to know this.
3. Neon now upgraded to 10.1.
4. Code in macros.rs needed to be adjusted for the new version of Neon. For example, [object property access has changed](https://github.com/neon-bindings/neon/blob/main/doc/MIGRATION_GUIDE_0.10.md#object-property-access-is-generic).
5. Dependencies like `@mapbox/node-pre-gyp` also updated.

~Tests for the changes have been added (for bug fixes / features)~
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

Part of MATTR's push to Node 18.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
