### PR TITLE
fix: publish unstable with node 18.x only

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -10,14 +10,11 @@ jobs:
     name: Build, test, and publish unstable release
     if: "contains(github.event.head_commit.message, 'chore(release): publish')"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
       - run: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn lint


### PR DESCRIPTION
## Description

Unfortunately made a mistake in release v0.16.0. This is a re-do of the release process, that will deploy a new version for node 18. 

~Tests for the changes have been added (for bug fixes / features)~
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

To fix an error with releasing, it is easier to simply produce a new release version, rather than repair the previous release.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
