### PR TITLE
ci: pin python version to 3.10.8 as node-gyp currently depends on it

### DIFF
--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           toolchain: stable
 
+      - run: node-gyp -v
+
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn build

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
-        # toolchain: [aarch64-apple-darwin] # not include windows due to node-gyp bug
+    #  toolchain: [aarch64-apple-darwin, ] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -19,10 +19,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # - uses: actions-rs/cargo@v1
-      #   with:
-      #     toolchain: stable
-      #     target: aarch64-apple-darwin
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
 
       - run: yarn install --frozen-lockfile
       - run: yarn lint

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           toolchain: stable
 
+      - run: yarn global add node-gyp
       - run: node-gyp -v
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [14.x, 16.x, 18.x]
-        os: [macos-14, ubuntu-22.04] # not include windows due to node-gyp bug
+        os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -11,12 +11,19 @@ jobs:
       matrix:
         node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
+        # toolchain: [aarch64-apple-darwin] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
+      # - uses: actions-rs/cargo@v1
+      #   with:
+      #     toolchain: stable
+      #     target: aarch64-apple-darwin
+
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn build

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -25,6 +25,9 @@ jobs:
       # Needed since since node-gyp depends on distutils package which has now been removed in python version 3.12
       - run: pip install setuptools
 
+      - run: yarn global add node-gyp@8.0.0
+      - run: node-gyp -v
+
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn build

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -9,9 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
-    #  toolchain: [aarch64-apple-darwin, ] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -23,10 +22,8 @@ jobs:
 
       # Setup up python tools
       # Needed since since node-gyp depends on distutils package which has now been removed in python version 3.12
+      # Only required for macos
       - run: pip install setuptools
-
-      - run: yarn global add node-gyp@8.0.0
-      - run: node-gyp -v
 
       - run: yarn install --frozen-lockfile
       - run: yarn lint

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [14.x, 16.x, 18.x]
-        os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
+        os: [macos-14, ubuntu-22.04] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -20,10 +20,9 @@ jobs:
 
       - run: python -V
 
-      # Setup up python tools
-      # Needed since since node-gyp depends on distutils package which has now been removed in python version 3.12
-      # Only required for macos
-      # - run: pip install setuptools
+      # Required as macos-14 defaults to use python 3.12, this causes issues with node-gyp currently
+      # 1. node-gyp depends on distutils package which has now been removed in python version 3.12 can use 'pip install setuptools' to fix this
+      # 2. Node@14 will error with -> Node gyp ERR - invalid mode: 'rU' while trying to load binding.gyp Where 'U' option is now deprecated
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10.8"

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v1
@@ -23,7 +23,10 @@ jobs:
       # Setup up python tools
       # Needed since since node-gyp depends on distutils package which has now been removed in python version 3.12
       # Only required for macos
-      - run: pip install setuptools
+      # - run: pip install setuptools
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10.8"
 
       - run: yarn install --frozen-lockfile
       - run: yarn lint

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -19,14 +19,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # - uses: actions-rs/toolchain@v1
-      #   with:
-      #     toolchain: stable
-
-      - run: yarn global add node-gyp
-      - run: node-gyp -v
-
       - run: python -V
+
+      # Setup up python tools
+      # Needed since since node-gyp depends on distutils package which has now been removed in python version 3.12
+      - run: pip install setuptools
 
       - run: yarn install --frozen-lockfile
       - run: yarn lint

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -19,12 +19,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      # - uses: actions-rs/toolchain@v1
+      #   with:
+      #     toolchain: stable
 
       - run: yarn global add node-gyp
       - run: node-gyp -v
+
+      - run: python -V
 
       - run: yarn install --frozen-lockfile
       - run: yarn lint

--- a/.github/workflows/any-pr.yml
+++ b/.github/workflows/any-pr.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # Logging python version for future debugging
       - run: python -V
 
       # Required as macos-14 defaults to use python 3.12, this causes issues with node-gyp currently


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

Required as macos-14 defaults to use python 3.12, this causes issues with node-gyp currently, ubuntu currently uses python 3.10 which is why only macos is failing.

1. node-gyp depends on distutils package which has now been removed in python version 3.12

>   ModuleNotFoundError: No module named 'distutils'

[CI action link](https://github.com/mattrglobal/node-bbs-signatures/actions/runs/8698375908/job/23855261101#step:6:747)

Could use `pip install setuptools` to fix this but that doesn't fix the issue below for Node 14

2. Node@14 will error with the following:

> Node gyp ERR - invalid mode: 'rU' while trying to load binding.gyp Where 'U' option is now deprecated

To fix this I downgraded python to get a compatible version



<!--- Describe your changes in detail -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
