### PR TITLE
Publish without Node 14.x

### DIFF
--- a/.github/workflows/push-binary-dispatch.yml
+++ b/.github/workflows/push-binary-dispatch.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         os: [macos-latest]
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         os: [macos-latest, ubuntu-latest] # not include windows due to node-gyp bug
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Forgot to remove Node 14.x from other jobs. This will make it possible to publish the library.

## Description

1. This will trigger the publish job, but avoid Node 14.x

- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

Fixes broken master

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [ ] Squash
- [x] Rebase (REVIEW COMMITS)
