### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 [![MATTR](./docs/assets/mattr-logo-square.svg)](https://github.com/mattrglobal)
 
+## Deprecation Notice
+
+This library has been deprecated in favor of the [Pairing Cryptography](https://github.com/mattrglobal/pairing_crypto)
+library which implements the more modern
+[BBS Signature Scheme](https://www.ietf.org/archive/id/draft-irtf-cfrg-bbs-signatures-03.html). There is no direct
+replacement, we recommend using
+[the WASM wrapper](https://github.com/mattrglobal/pairing_crypto/tree/master/wrappers/wasm).
+
 # Node BBS Signatures
 
 ![npm-version](https://badgen.net/npm/v/@mattrglobal/node-bbs-signatures)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This library has been deprecated in favor of the [Pairing Cryptography](https://github.com/mattrglobal/pairing_crypto)
 library which implements the more modern
-[BBS Signature Scheme](https://www.ietf.org/archive/id/draft-irtf-cfrg-bbs-signatures-03.html). There is no direct
+[BBS Signature Scheme](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/). There is no direct
 replacement, we recommend using
 [the WASM wrapper](https://github.com/mattrglobal/pairing_crypto/tree/master/wrappers/wasm).
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 This library has been deprecated in favor of the [Pairing Cryptography](https://github.com/mattrglobal/pairing_crypto)
 library which implements the more modern
-[BBS Signature Scheme](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/). There is no direct
-replacement, we recommend using
-[the WASM wrapper](https://github.com/mattrglobal/pairing_crypto/tree/master/wrappers/wasm).
+[BBS Signature Scheme](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/).
+
+We recommend using the [WASM wrapper](https://github.com/mattrglobal/pairing_crypto/tree/master/wrappers/wasm). There is
+no direct replacement.
 
 # Node BBS Signatures
 


### PR DESCRIPTION
## Description

Deprecate the library in favor of the `pairing_crypto` WASM wrapper.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../CONTRIBUTING.md)** document.

## Motivation and Context

Library deprecation

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
